### PR TITLE
Buffer rewrite

### DIFF
--- a/engine/Framework/component/RenderComponent/CameraComponent.h
+++ b/engine/Framework/component/RenderComponent/CameraComponent.h
@@ -44,6 +44,9 @@ namespace Engine
         CameraComponent & set_clipping(float near, float far);
 
     public:
+        /// Internal id for the underlying rendering resource of the camera.
+        /// _Should_ be unique for each camera that needs to be rendered in _the same frame_.
+        REFL_SER_ENABLE uint8_t display_id {0};
         REFL_SER_ENABLE float m_fov_vertical{45};
         REFL_SER_ENABLE float m_aspect_ratio{1.0};
         REFL_SER_ENABLE float m_clipping_near{1e-3};

--- a/engine/Render/ConstantData/PerCameraConstants.h
+++ b/engine/Render/ConstantData/PerCameraConstants.h
@@ -3,7 +3,7 @@
 
 #include <glm.hpp>
 #include "Render/VkWrapper.tcc"
-#include "Render/Memory/Buffer.h"
+#include "Render/Memory/IndexedBuffer.h"
 
 namespace Engine {
     class RenderSystem;
@@ -19,7 +19,7 @@ namespace Engine {
             static constexpr std::array <vk::DescriptorSetLayoutBinding, 1> BINDINGS = {
                 vk::DescriptorSetLayoutBinding{
                     0,
-                    vk::DescriptorType::eUniformBuffer,
+                    vk::DescriptorType::eUniformBufferDynamic,
                     1,
                     vk::ShaderStageFlagBits::eAllGraphics
                 }

--- a/engine/Render/Memory/AllocatedMemory.h
+++ b/engine/Render/Memory/AllocatedMemory.h
@@ -27,9 +27,37 @@ namespace Engine {
         vk::Buffer GetBuffer() const;
         vk::Image GetImage() const;
 
+        /**
+         * @brief Map the memory to a host pointer.
+         * 
+         * The pointer is cached in the class and automatically unmapped
+         * on deconstruction. You don't need to match `UnmapMemory()` manually
+         * before cleaning up.
+         */
         std::byte * MapMemory();
+
+        /**
+         * @brief Flush the memory write to be visible on device.
+         * 
+         * Generally you don't need to manually call this member, as memories that
+         * need to be flushed are usually coherent.
+         */
         void FlushMemory (size_t offset = 0, size_t size = 0);
+    
+        /**
+         * @brief Invalidate the memory so that device write are visible on host.
+         * 
+         * Generally you don't need to manually call this member, as memories that
+         * need to be invalidated are usually coherent.
+         */
         void InvalidateMemory (size_t offset = 0, size_t size = 0);
+
+        /**
+         * @brief Unmap the host pointer and reset the cached pointer.
+         * 
+         * Generally you don't need to manually call this member, as clean up is
+         * automatically done with RAII mechanism.
+         */
         void UnmapMemory();
     };
 }

--- a/engine/Render/Memory/Buffer.h
+++ b/engine/Render/Memory/Buffer.h
@@ -1,5 +1,5 @@
-#ifndef RENDER_PIPELINE_MEMORY_BUFFER_INCLUDED
-#define RENDER_PIPELINE_MEMORY_BUFFER_INCLUDED
+#ifndef RENDER_MEMORY_BUFFER_INCLUDED
+#define RENDER_MEMORY_BUFFER_INCLUDED
 
 #include <vulkan/vulkan.hpp>
 #include <memory>
@@ -28,9 +28,42 @@ namespace Engine{
 
         size_t GetSize() const;
 
+        /**
+         * @brief Map the buffer memory to a host pointer.
+         * 
+         * The pointer is automatically unmapped on deconstruction.
+         * You don't need to match `Unmap()` manually before cleaning up.
+         */
         std::byte * Map() const;
+
+        /**
+         * @brief Flush the memory write to be visible on device.
+         * 
+         * Generally you don't need to manually call this member, as memories that
+         * need to be flushed are usually coherent.
+         * 
+         * @param offset Offset of the region to be flushed
+         * @param size Size of the region to be flushed, or whole region if 0.
+         */
         void Flush(size_t offset = 0, size_t size = 0) const;
+
+        /**
+         * @brief Invalidate the memory so that device write are visible on host.
+         * 
+         * Generally you don't need to manually call this member, as memories that
+         * need to be invalidated are usually coherent.
+         * 
+         * @param offset Offset of the region to be invalidated
+         * @param size Size of the region to be invalidated, or whole region if 0.
+         */
         void Invalidate (size_t offset = 0, size_t size = 0) const;
+
+        /**
+         * @brief Unmap the host pointer.
+         * 
+         * Generally you don't need to manually call this member, as clean up is
+         * automatically done by the underlying `AllocatedMemory`.
+         */
         void Unmap() const;
     
     protected:
@@ -41,4 +74,4 @@ namespace Engine{
     };
 }
 
-#endif // RENDER_PIPELINE_MEMORY_BUFFER_INCLUDED
+#endif // RENDER_MEMORY_BUFFER_INCLUDED

--- a/engine/Render/Memory/IndexedBuffer.cpp
+++ b/engine/Render/Memory/IndexedBuffer.cpp
@@ -32,6 +32,16 @@ namespace Engine {
         assert(pimpl->base_ptr);
     }
 
+    size_t IndexedBuffer::GetSliceSize() const noexcept
+    {
+        return pimpl->slice_size;
+    }
+
+    size_t IndexedBuffer::GetAlignedSliceSize() const noexcept
+    {
+        return pimpl->aligned_slice_size;
+    }
+
     void *IndexedBuffer::GetSlicePtr(uint32_t slice) const noexcept
     {
         assert(slice < pimpl->slices);

--- a/engine/Render/Memory/IndexedBuffer.cpp
+++ b/engine/Render/Memory/IndexedBuffer.cpp
@@ -1,0 +1,55 @@
+#include "IndexedBuffer.h"
+
+namespace Engine {
+
+    struct IndexedBuffer::impl {
+        size_t slice_size;
+        size_t slice_alignment;
+        uint32_t slices;
+
+        size_t aligned_slice_size;
+        void * base_ptr;
+    };
+
+    IndexedBuffer::IndexedBuffer(
+        RenderSystem &system
+    ) : Buffer(system), pimpl(std::make_unique<IndexedBuffer::impl>())
+    {
+    }
+
+    IndexedBuffer::~IndexedBuffer() = default;
+
+    void IndexedBuffer::Create(BufferType type, size_t slice_size, size_t slice_alignment, uint32_t slices, const std::string &name)
+    {
+        assert(type == BufferType::Uniform && "Currently only uniform buffer can be indexed.");
+        std::tie(pimpl->slice_size, pimpl->slice_alignment, pimpl->slices) = {slice_size, slice_alignment, slices};
+
+        size_t aligned_size = slice_alignment ? ((slice_size + slice_alignment - 1) & ~(slice_alignment - 1)) : slice_size;
+        pimpl->aligned_slice_size = aligned_size;
+
+        Buffer::Create(type, aligned_size * slices, name);
+        pimpl->base_ptr = Buffer::Map();
+        assert(pimpl->base_ptr);
+    }
+
+    void *IndexedBuffer::GetSlicePtr(uint32_t slice) const noexcept
+    {
+        assert(slice < pimpl->slices);
+        return pimpl->base_ptr + pimpl->aligned_slice_size * slice;
+    }
+
+    std::ptrdiff_t IndexedBuffer::GetSliceOffset(uint32_t slice) const noexcept
+    {
+        return pimpl->aligned_slice_size * slice;
+    }
+
+    void IndexedBuffer::FlushSlice(uint32_t slice) const
+    {
+        Buffer::Flush(GetSliceOffset(slice), pimpl->aligned_slice_size);
+    }
+
+    void IndexedBuffer::InvalidateSlice(uint32_t slice)
+    {
+        Buffer::Invalidate(GetSliceOffset(slice), pimpl->aligned_slice_size);
+    }
+}

--- a/engine/Render/Memory/IndexedBuffer.h
+++ b/engine/Render/Memory/IndexedBuffer.h
@@ -8,9 +8,9 @@ namespace Engine {
     /**
      * @brief Buffer of a large trunk of memory.
      * The buffer is separated into multiple slices of the same size, and
-     * each slice can be indexed for a base pointer.
+     * each slice can be indexed for a slice pointer.
      * 
-     * The base pointer is guaranteed to be aligned accordingly, making the
+     * The slice pointer is guaranteed to be aligned accordingly, making the
      * buffer suitable to use for dynamic buffer descriptors.
      */
     class IndexedBuffer : private Buffer {
@@ -23,6 +23,14 @@ namespace Engine {
         IndexedBuffer (RenderSystem & system);
         virtual ~IndexedBuffer ();
 
+        /**
+         * @brief Create a buffer that is large enough to hold aligned slices.
+         * 
+         * @param type Type of the buffer. Currently only uniform is supported.
+         * @param slice_size Actual size of each slice, ignoring alignment requirement.
+         * @param slice_alignment Alignment requirement of each slice.
+         * @param name Name of the buffer.
+         */
         void Create (
             BufferType type, 
             size_t slice_size, 
@@ -37,16 +45,35 @@ namespace Engine {
         /**
          * @brief Get the pointer to the slice.
          * 
+         * The slice pointer is aligned to guarantee that
+         * `GetSlicePtr(slice) % slice_alignment == 0`.
+         * 
          * The pointer is already offset, and you do not need to offset it again.
          */
         void * GetSlicePtr(uint32_t slice) const noexcept;
 
         /**
          * @brief Get the offset of the slice to the base pointer mapped.
+         * 
+         * The slice pointer is aligned to guarantee that
+         * `GetSliceOffset(slice) % slice_alignment == 0`.
          */
         std::ptrdiff_t GetSliceOffset(uint32_t slice) const noexcept;
         
+        /**
+         * @brief Flush the slice write to be visible on device.
+         * 
+         * Generally you don't need to manually call this member, as memories that
+         * need to be flushed are usually coherent.
+         */
         void FlushSlice(uint32_t slice) const;
+
+        /**
+         * @brief Invalidate the slice so that device write are visible on host.
+         * 
+         * Generally you don't need to manually call this member, as memories that
+         * need to be invalidated are usually coherent.
+         */
         void InvalidateSlice(uint32_t slice);
     };
 
@@ -58,6 +85,11 @@ namespace Engine {
     public:
         TypedIndexedBuffer(RenderSystem & sys) : IndexedBuffer(sys) {};
 
+        /**
+         * @brief Create the buffer object and perform allocation accordingly.
+         * 
+         * Effectively calls `IndexedBuffer::Create(type, sizeof(T), slice_alignment, slices, name)`.
+         */
         void Create(
             BufferType type,
             size_t slice_alignment,
@@ -67,6 +99,9 @@ namespace Engine {
             IndexedBuffer::Create(type, sizeof(T), slice_alignment, slices, name);
         }
 
+        /**
+         * @brief Get a typed pointer to the slice.
+         */
         T* GetSlicePtrTyped (uint32_t slice) const noexcept {
             return reinterpret_cast<T *>(GetSlicePtr(slice));
         }

--- a/engine/Render/Memory/IndexedBuffer.h
+++ b/engine/Render/Memory/IndexedBuffer.h
@@ -1,0 +1,76 @@
+#ifndef RENDER_MEMORY_INDEXEDBUFFER_INCLUDED
+#define RENDER_MEMORY_INDEXEDBUFFER_INCLUDED
+
+#include "Render/Memory/Buffer.h"
+
+namespace Engine {
+
+    /**
+     * @brief Buffer of a large trunk of memory.
+     * The buffer is separated into multiple slices of the same size, and
+     * each slice can be indexed for a base pointer.
+     * 
+     * The base pointer is guaranteed to be aligned accordingly, making the
+     * buffer suitable to use for dynamic buffer descriptors.
+     */
+    class IndexedBuffer : private Buffer {
+        struct impl;
+        std::unique_ptr <impl> pimpl;
+
+    public:
+        using Buffer::BufferType;
+
+        IndexedBuffer (RenderSystem & system);
+        virtual ~IndexedBuffer ();
+
+        void Create (
+            BufferType type, 
+            size_t slice_size, 
+            size_t slice_alignment, 
+            uint32_t slices, 
+            const std::string & name = ""
+        );
+
+        using Buffer::GetBuffer;
+        using Buffer::GetSize;
+
+        /**
+         * @brief Get the pointer to the slice.
+         * 
+         * The pointer is already offset, and you do not need to offset it again.
+         */
+        void * GetSlicePtr(uint32_t slice) const noexcept;
+
+        /**
+         * @brief Get the offset of the slice to the base pointer mapped.
+         */
+        std::ptrdiff_t GetSliceOffset(uint32_t slice) const noexcept;
+        
+        void FlushSlice(uint32_t slice) const;
+        void InvalidateSlice(uint32_t slice);
+    };
+
+    /**
+     * @brief A typed adaptor of `IndexedBuffer`.
+     */
+    template <class T> requires std::is_standard_layout_v<T>
+    class TypedIndexedBuffer : public IndexedBuffer {
+    public:
+        TypedIndexedBuffer(RenderSystem & sys) : IndexedBuffer(sys) {};
+
+        void Create(
+            BufferType type,
+            size_t slice_alignment,
+            uint32_t slices,
+            const std::string & name = ""
+        ) {
+            IndexedBuffer::Create(type, sizeof(T), slice_alignment, slices, name);
+        }
+
+        T* GetSlicePtrTyped (uint32_t slice) const noexcept {
+            return reinterpret_cast<T *>(GetSlicePtr(slice));
+        }
+    };
+}
+
+#endif // RENDER_MEMORY_INDEXEDBUFFER_INCLUDED

--- a/engine/Render/Memory/IndexedBuffer.h
+++ b/engine/Render/Memory/IndexedBuffer.h
@@ -43,6 +43,16 @@ namespace Engine {
         using Buffer::GetSize;
 
         /**
+         * @brief Get actual slice size ignoring padding for alignments.
+         */
+        size_t GetSliceSize() const noexcept;
+
+        /**
+         * @brief Get slice size with alignment
+         */
+        size_t GetAlignedSliceSize() const noexcept;
+
+        /**
          * @brief Get the pointer to the slice.
          * 
          * The slice pointer is aligned to guarantee that

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
@@ -120,7 +120,7 @@ namespace Engine
         }
 
         const auto & global_pool = m_system.GetGlobalConstantDescriptorPool();
-        const auto & per_scenc_descriptor_set = global_pool.GetPerSceneConstantSet(m_inflight_frame_index);
+        const auto & per_scene_descriptor_set = global_pool.GetPerSceneConstantSet(m_inflight_frame_index);
         const auto & per_camera_descriptor_set = global_pool.GetPerCameraConstantSet(m_inflight_frame_index);
         auto material_descriptor_set = material.GetDescriptor(pass_index);
 
@@ -129,16 +129,16 @@ namespace Engine
                 vk::PipelineBindPoint::eGraphics, 
                 pipeline_layout, 
                 0,
-                {per_scenc_descriptor_set, per_camera_descriptor_set, material_descriptor_set},
-                {}
+                {per_scene_descriptor_set, per_camera_descriptor_set, material_descriptor_set},
+                { static_cast<uint32_t>(global_pool.GetPerCameraDynamicOffset(m_inflight_frame_index, m_system.GetActiveCameraId())) }
             );
         } else {
             cb.bindDescriptorSets(
                 vk::PipelineBindPoint::eGraphics, 
                 pipeline_layout, 
                 0,
-                {per_scenc_descriptor_set, per_camera_descriptor_set},
-                {}
+                {per_scene_descriptor_set, per_camera_descriptor_set},
+                { static_cast<uint32_t>(global_pool.GetPerCameraDynamicOffset(m_inflight_frame_index, m_system.GetActiveCameraId())) }
             );
         }
         

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
@@ -50,9 +50,16 @@ namespace Engine {
             const std::string & name = ""
         );
 
-        /// @brief Bind a material for rendering, and write per-material descriptors.
-        /// @param material 
-        /// @param pass_index 
+        /**
+         * @brief Bind a material for rendering.
+         * 
+         * Bind new material pipeline to the GPU (if warranted), bind descriptors to the pipeline,
+         * and write pending uniform data updates of the given material instance.
+         * 
+         * @note Camera data is uploaded to the pipeline in this method call. If camera switch occurred,
+         * this method must be called again even if material is the same. This case should be handled
+         * by the render system.
+         */
         void BindMaterial(MaterialInstance & material, uint32_t pass_index);
 
         /// @brief Setup the viewport parameters

--- a/engine/Render/Pipeline/Material/MaterialInstance.cpp
+++ b/engine/Render/Pipeline/Material/MaterialInstance.cpp
@@ -117,7 +117,7 @@ namespace Engine {
     {
         assert(pimpl->m_pass_info.contains(pass) && "Cannot find pass.");
         auto & pass_info = pimpl->m_pass_info[pass];
-        auto fif = m_system.GetFrameManager().GetFrameInFlight() % pass_info.BACK_BUFFERS;
+        auto fif = m_system.GetFrameManager().GetTotalFrame() % pass_info.BACK_BUFFERS;
         if (!pass_info._is_ubo_dirty[fif])    return;
 
         auto tpl = pimpl->m_parent_template.lock();
@@ -125,7 +125,7 @@ namespace Engine {
         // write uniform buffer
         auto & ubo = *(pass_info.ubo.get());
         tpl->PlaceUBOVariables(*this, pimpl->m_buffer, pass);
-        std::memcpy(ubo.GetSlicePtr(fif), pimpl->m_buffer.data(), ubo.GetSize());
+        std::memcpy(ubo.GetSlicePtr(fif), pimpl->m_buffer.data(), ubo.GetSliceSize());
         ubo.FlushSlice(fif);
 
         pass_info._is_ubo_dirty.reset(fif);
@@ -135,7 +135,7 @@ namespace Engine {
     {
         assert(pimpl->m_pass_info.contains(pass) && "Cannot find pass.");
         auto & pass_info = pimpl->m_pass_info[pass];
-        auto fif = m_system.GetFrameManager().GetFrameInFlight() % pass_info.BACK_BUFFERS;
+        auto fif = m_system.GetFrameManager().GetTotalFrame() % pass_info.BACK_BUFFERS;
         if (!(pass_info.desc_set[fif]))    return;
         if (!pass_info._is_descriptor_set_dirty[fif])    return;
 
@@ -184,7 +184,7 @@ namespace Engine {
     }
     vk::DescriptorSet MaterialInstance::GetDescriptor(uint32_t pass) const
     {
-        return GetDescriptor(pass, m_system.GetFrameManager().GetFrameInFlight() % impl::PassInfo::BACK_BUFFERS);
+        return GetDescriptor(pass, m_system.GetFrameManager().GetTotalFrame() % impl::PassInfo::BACK_BUFFERS);
     }
     vk::DescriptorSet MaterialInstance::GetDescriptor(uint32_t pass, uint32_t backbuffer) const
     {

--- a/engine/Render/Pipeline/Material/MaterialInstance.cpp
+++ b/engine/Render/Pipeline/Material/MaterialInstance.cpp
@@ -7,58 +7,93 @@
 #include <Asset/Material/MaterialAsset.h>
 #include <Asset/Texture/Image2DTextureAsset.h>
 #include <SDL3/SDL.h>
+#include <Render/Memory/IndexedBuffer.h>
+#include <bitset>
 
 namespace Engine {
+
+    struct MaterialInstance::impl {
+        struct PassInfo {
+            static constexpr uint32_t BACK_BUFFERS = 2;
+
+            std::unique_ptr <IndexedBuffer> ubo {};
+            std::array <vk::DescriptorSet, BACK_BUFFERS> desc_set {};
+
+            std::bitset <BACK_BUFFERS> _is_descriptor_set_dirty{};
+            std::bitset <BACK_BUFFERS> _is_ubo_dirty{};
+        };
+
+        std::weak_ptr <MaterialTemplate> m_parent_template;
+        std::unordered_map <uint32_t, std::unordered_map<uint32_t, std::any>> m_desc_variables {};
+        std::unordered_map <uint32_t, std::unordered_map<uint32_t, std::any>> m_inblock_variables {};
+        std::unordered_map <uint32_t, PassInfo> m_pass_info {};
+
+        // A small buffer for uniform buffer staging to avoid random write to UBO.
+        std::vector <std::byte> m_buffer {};
+    };
+
     MaterialInstance::MaterialInstance(
         RenderSystem & system, 
         std::shared_ptr<MaterialTemplate> tpl
-        ) : m_system(system), m_parent_template(tpl)
+        ) : m_system(system), pimpl(std::make_unique<impl>(tpl))
     {
+        using PassInfo = impl::PassInfo;
         // Allocate uniform buffers and per-material descriptor sets
         for (const auto & [idx, info] : tpl->GetAllPassInfo()) {
             PassInfo pass{};
             auto ubo_size = tpl->GetMaximalUBOSize(idx);
-            pass.desc_set = tpl->AllocateDescriptorSet(idx);
+            pass.desc_set[0] = tpl->AllocateDescriptorSet(idx);
+            pass.desc_set[1] = tpl->AllocateDescriptorSet(idx);
             if (ubo_size == 0) {
                 SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "Found zero-sized UBO when processing pass %llu of material", ubo_size);
             } else {
-                pass.ubo = std::make_unique<Buffer>(system);
-                pass.ubo->Create(Buffer::BufferType::Uniform, tpl->GetMaximalUBOSize(idx));
+                pass.ubo = std::make_unique<IndexedBuffer>(system);
+                pass.ubo->Create(
+                    Buffer::BufferType::Uniform,
+                    tpl->GetMaximalUBOSize(idx),
+                    system.GetPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment,
+                    PassInfo::BACK_BUFFERS,
+                    "Indexed UBO for Material"
+                );
             }
-            m_pass_info[idx] = std::move(pass);
+            pimpl->m_pass_info[idx] = std::move(pass);
         }
     }
 
+    MaterialInstance::~MaterialInstance() = default;
+
     const MaterialTemplate &MaterialInstance::GetTemplate() const
     {
-        return *m_parent_template.lock();
+        return *(pimpl->m_parent_template.lock());
     }
 
-    auto MaterialInstance::GetInBlockVariables(uint32_t pass_index) const -> const decltype(m_inblock_variables.at(0)) &
+    const std::unordered_map<uint32_t, std::any> & 
+    MaterialInstance::GetInBlockVariables(uint32_t pass_index) const
     {
-        return m_inblock_variables.at(pass_index);
+        return pimpl->m_inblock_variables.at(pass_index);
     }
 
-    auto MaterialInstance::GetDescVariables(uint32_t pass_index) const -> const decltype(m_desc_variables.at(0)) &
+    const std::unordered_map<uint32_t, std::any> & 
+    MaterialInstance::GetDescVariables(uint32_t pass_index) const
     {
-        return m_desc_variables.at(pass_index);
+        return pimpl->m_desc_variables.at(pass_index);
     }
 
     void MaterialInstance::WriteTextureUniform(uint32_t pass, uint32_t index, std::shared_ptr <const SampledTexture> texture)
     {
-        assert(m_pass_info.contains(pass) && "Cannot find pass.");
+        assert(pimpl->m_pass_info.contains(pass) && "Cannot find pass.");
         assert(
-            m_parent_template.lock()->GetDescVariable(index, pass).set
+            pimpl->m_parent_template.lock()->GetDescVariable(index, pass).set
             && "Cannot find uniform in designated pass."
         );
 
-        m_desc_variables[pass][index] = std::any(texture);
-        m_pass_info[pass].is_descriptor_set_dirty = true;
+        pimpl->m_desc_variables[pass][index] = std::any(texture);
+        pimpl->m_pass_info[pass]._is_descriptor_set_dirty.set();
     }
 
     void MaterialInstance::WriteStorageBufferUniform(uint32_t pass, uint32_t index, std::shared_ptr <const Buffer> buffer)
     {
-        assert(false && "Unimplemented");
+        assert(!"Unimplemented");
     }
 
     void MaterialInstance::WriteUBOUniform(uint32_t pass, uint32_t index, std::any uniform)
@@ -68,42 +103,43 @@ namespace Engine {
             != PipelineUtils::REGISTERED_SHADER_UNIFORM_TYPES.end()
             && "Unsupported uniform type."
         );
-        assert(m_pass_info.find(pass) != m_pass_info.end() && "Cannot find pass.");
+        assert(pimpl->m_pass_info.find(pass) != pimpl->m_pass_info.end() && "Cannot find pass.");
         assert(
-            m_parent_template.lock()->GetInBlockVariable(index, pass).block_location.set
+            pimpl->m_parent_template.lock()->GetInBlockVariable(index, pass).block_location.set
             && "Cannot find uniform in designated pass."
         );
 
-        m_inblock_variables[pass][index] = uniform;
-        m_pass_info[pass].is_ubo_dirty = true;
+        pimpl->m_inblock_variables[pass][index] = uniform;
+        pimpl->m_pass_info[pass]._is_ubo_dirty.set();
     }
 
     void MaterialInstance::WriteUBO(uint32_t pass)
     {
-        assert(m_pass_info.contains(pass) && "Cannot find pass.");
-        auto & pass_info = m_pass_info[pass];
-        if (!pass_info.is_ubo_dirty)    return;
+        assert(pimpl->m_pass_info.contains(pass) && "Cannot find pass.");
+        auto & pass_info = pimpl->m_pass_info[pass];
+        auto fif = m_system.GetFrameManager().GetFrameInFlight() % pass_info.BACK_BUFFERS;
+        if (!pass_info._is_ubo_dirty[fif])    return;
 
-        auto tpl = m_parent_template.lock();
+        auto tpl = pimpl->m_parent_template.lock();
 
         // write uniform buffer
         auto & ubo = *(pass_info.ubo.get());
-        tpl->PlaceUBOVariables(*this, m_buffer, pass);
-        std::memcpy(ubo.Map(), m_buffer.data(), ubo.GetSize());
-        ubo.Flush();
+        tpl->PlaceUBOVariables(*this, pimpl->m_buffer, pass);
+        std::memcpy(ubo.GetSlicePtr(fif), pimpl->m_buffer.data(), ubo.GetSize());
+        ubo.FlushSlice(fif);
 
-        pass_info.is_ubo_dirty = false;
+        pass_info._is_ubo_dirty.reset(fif);
     }
 
     void MaterialInstance::WriteDescriptors(uint32_t pass)
     {
-        assert(m_pass_info.contains(pass) && "Cannot find pass.");
-        auto & pass_info = m_pass_info[pass];
+        assert(pimpl->m_pass_info.contains(pass) && "Cannot find pass.");
+        auto & pass_info = pimpl->m_pass_info[pass];
+        auto fif = m_system.GetFrameManager().GetFrameInFlight() % pass_info.BACK_BUFFERS;
+        if (!(pass_info.desc_set[fif]))    return;
+        if (!pass_info._is_descriptor_set_dirty[fif])    return;
 
-        if (!pass_info.desc_set)    return;
-        if (!pass_info.is_descriptor_set_dirty)    return;
-
-        auto tpl = m_parent_template.lock();
+        auto tpl = pimpl->m_parent_template.lock();
         
         
         // Prepare descriptor writes
@@ -113,7 +149,7 @@ namespace Engine {
         writes.reserve(image_writes.size() + 1);
         for (const auto & [binding, image_info] : image_writes) {
             vk::WriteDescriptorSet write {
-                    pass_info.desc_set, binding, 0, 1,
+                    pass_info.desc_set[fif], binding, 0, 1,
                     // TODO: We need a better way to check if its storage image or texture image.
                     image_info.imageLayout == vk::ImageLayout::eGeneral ? 
                         vk::DescriptorType::eStorageImage : 
@@ -127,10 +163,14 @@ namespace Engine {
         if (pass_info.ubo) {
             auto & ubo = *(pass_info.ubo.get());
             std::array <vk::DescriptorBufferInfo, 1> ubo_buffer_info = {
-                vk::DescriptorBufferInfo{ubo.GetBuffer(), 0, vk::WholeSize}
+                vk::DescriptorBufferInfo{
+                    ubo.GetBuffer(),
+                    ubo.GetSliceOffset(fif),
+                    ubo.GetSliceSize()
+                }
             };
             vk::WriteDescriptorSet ubo_write {
-                pass_info.desc_set, 0, 0,
+                pass_info.desc_set[fif], 0, 0,
                 vk::DescriptorType::eUniformBuffer,
                 {},
                 ubo_buffer_info,
@@ -140,15 +180,20 @@ namespace Engine {
         }
 
         m_system.getDevice().updateDescriptorSets(writes, {});
-        pass_info.is_descriptor_set_dirty = false;
+        pass_info._is_descriptor_set_dirty.reset(fif);
     }
     vk::DescriptorSet MaterialInstance::GetDescriptor(uint32_t pass) const
     {
-        return m_pass_info.at(pass).desc_set;
+        return GetDescriptor(pass, m_system.GetFrameManager().GetFrameInFlight() % impl::PassInfo::BACK_BUFFERS);
+    }
+    vk::DescriptorSet MaterialInstance::GetDescriptor(uint32_t pass, uint32_t backbuffer) const
+    {
+        assert(backbuffer < impl::PassInfo::BACK_BUFFERS);
+        return pimpl->m_pass_info.at(pass).desc_set[backbuffer];
     }
     void MaterialInstance::Instantiate(const MaterialAsset &asset)
     {
-        const auto & all_passes = m_parent_template.lock()->GetAllPassInfo();
+        const auto & all_passes = pimpl->m_parent_template.lock()->GetAllPassInfo();
         for(const auto & [pass_index, pass_info] : all_passes)
         {
             for(const auto & [uniform_name, uniform_idx] : pass_info.inblock.names) {

--- a/engine/Render/RenderSystem.cpp
+++ b/engine/Render/RenderSystem.cpp
@@ -125,7 +125,9 @@ namespace Engine
         GraphicsCommandBuffer cb = this->GetFrameManager().GetCommandBuffer();
 
         // Write camera transforms
-        std::byte * camera_ptr = this->GetGlobalConstantDescriptorPool().GetPerCameraConstantMemory(pimpl->m_frame_manager.GetFrameInFlight());
+        auto camera_ptr = this->GetGlobalConstantDescriptorPool().GetPerCameraConstantMemory(
+            pimpl->m_frame_manager.GetFrameInFlight(), GetActiveCameraId()
+        );
         ConstantData::PerCameraStruct camera_struct {
             view_matrix, projection_matrix
         };
@@ -164,6 +166,11 @@ namespace Engine
     void RenderSystem::SetActiveCamera(std::shared_ptr <CameraComponent> cameraComponent)
     {
         pimpl->m_active_camera = cameraComponent;
+    }
+
+    uint32_t RenderSystem::GetActiveCameraId() const
+    {
+        return pimpl->m_active_camera ? pimpl->m_active_camera->display_id : 0;
     }
 
     vk::Instance RenderSystem::getInstance() const 
@@ -221,9 +228,9 @@ namespace Engine
     }
 
     void RenderSystem::WritePerCameraConstants(const ConstantData::PerCameraStruct& data, uint32_t in_flight_index) {
-        std::byte * ptr = pimpl->m_descriptor_pool.GetPerCameraConstantMemory(in_flight_index);
+        auto * ptr = pimpl->m_descriptor_pool.GetPerCameraConstantMemory(in_flight_index, GetActiveCameraId());
         std::memcpy(ptr, &data, sizeof data);
-        pimpl->m_descriptor_pool.FlushPerCameraConstantMemory(in_flight_index);
+        pimpl->m_descriptor_pool.FlushPerCameraConstantMemory(in_flight_index, GetActiveCameraId());
     }
 
     void RenderSystem::WaitForIdle() const {

--- a/engine/Render/RenderSystem.h
+++ b/engine/Render/RenderSystem.h
@@ -77,6 +77,7 @@ namespace Engine
         void ClearComponent();
 
         void SetActiveCamera(std::shared_ptr <CameraComponent>);
+        uint32_t GetActiveCameraId() const;
         void WaitForIdle() const;
 
         /// @brief Update the swapchain in response of a window resize etc.

--- a/engine/Render/RenderSystem/AllocatorState.cpp
+++ b/engine/Render/RenderSystem/AllocatorState.cpp
@@ -23,7 +23,7 @@ namespace Engine::RenderSystemState {
             case BufferType::Uniform:
                 return std::make_tuple(
                     vk::BufferUsageFlagBits::eUniformBuffer,
-                    VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT,
+                    VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT,
                     VMA_MEMORY_USAGE_AUTO_PREFER_HOST
                     );
         }

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -322,6 +322,11 @@ namespace Engine::RenderSystemState{
         return this->pimpl->current_frame_in_flight;
     }
 
+    uint64_t FrameManager::GetTotalFrame() const noexcept
+    {
+        return pimpl->total_frame_count;
+    }
+
     uint32_t FrameManager::GetFramebuffer() const noexcept
     {
         assert(this->pimpl->current_framebuffer < std::numeric_limits<uint32_t>::max() && "Frame Manager is in invalid state.");

--- a/engine/Render/RenderSystem/FrameManager.h
+++ b/engine/Render/RenderSystem/FrameManager.h
@@ -24,6 +24,9 @@ namespace Engine {
             void Create ();
 
             uint32_t GetFrameInFlight() const noexcept;
+
+            uint64_t GetTotalFrame() const noexcept;
+
             uint32_t GetFramebuffer() const noexcept;
             
             /**

--- a/engine/Render/RenderSystem/GlobalConstantDescriptorPool.cpp
+++ b/engine/Render/RenderSystem/GlobalConstantDescriptorPool.cpp
@@ -74,7 +74,7 @@ namespace Engine::RenderSystemState{
         std::vector <vk::WriteDescriptorSet> writes {inflight_frame_count * 2};
         for (uint32_t i = 0; i < inflight_frame_count; i++) {
             buffers[i] = vk::DescriptorBufferInfo{
-                m_per_camera_buffers[i]->GetBuffer(), 0, vk::WholeSize 
+                m_per_camera_buffers[i]->GetBuffer(), 0, sizeof(ConstantData::PerCameraStruct) 
             };
             buffers[i + inflight_frame_count] = vk::DescriptorBufferInfo{
                 m_per_scene_buffers[i].GetBuffer(), 0, vk::WholeSize

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -130,9 +130,9 @@ int main(int argc, char ** argv)
         auto ptr = global_pool.GetPerSceneConstantMemory(i);
         memcpy(ptr, &scene, sizeof scene);
         global_pool.FlushPerSceneConstantMemory(i); 
-        std::byte * camera_ptr = global_pool.GetPerCameraConstantMemory(i);
+        auto camera_ptr = global_pool.GetPerCameraConstantMemory(i, 0);
         std::memcpy(camera_ptr, &camera_mats, sizeof camera_mats);
-        global_pool.FlushPerCameraConstantMemory(i);
+        global_pool.FlushPerCameraConstantMemory(i, 0);
     }
 
     glm::mat4 eye4 = glm::mat4(1.0f);

--- a/test/shadow_map_test.cpp
+++ b/test/shadow_map_test.cpp
@@ -133,9 +133,9 @@ int main(int argc, char ** argv)
         auto ptr = global_pool.GetPerSceneConstantMemory(i);
         memcpy(ptr, &scene, sizeof scene);
         global_pool.FlushPerSceneConstantMemory(i); 
-        std::byte * camera_ptr = global_pool.GetPerCameraConstantMemory(i);
+        auto camera_ptr = global_pool.GetPerCameraConstantMemory(i, 0);
         std::memcpy(camera_ptr, &camera_mats, sizeof camera_mats);
-        global_pool.FlushPerCameraConstantMemory(i);
+        global_pool.FlushPerCameraConstantMemory(i, 0);
     }
 
     glm::mat4 eye4 = glm::mat4(1.0f);


### PR DESCRIPTION
Rewrite buffer code to use indexed buffer for camera and material uniform buffers. Resolves #42 and potential uniform buffer host-device read-after-write hazards (which are fortunately not exposed unless on a very slow GPU).