### PR TITLE
Mesh rework - Part 1

### DIFF
--- a/editor/Editor/Widget/GameWidget.cpp
+++ b/editor/Editor/Widget/GameWidget.cpp
@@ -77,8 +77,7 @@ namespace Editor {
             Engine::MainClass::GetInstance()->GetWorldSystem()->m_active_camera
         );
         cb.DrawRenderers(
-            Engine::MainClass::GetInstance()->GetRenderSystem()->GetRendererManager().FilterAndSortRenderers({}),
-            0
+            Engine::MainClass::GetInstance()->GetRenderSystem()->GetRendererManager().FilterAndSortRenderers({}), 0
         );
         cb.EndRendering();
     }

--- a/editor/Editor/Widget/GameWidget.cpp
+++ b/editor/Editor/Widget/GameWidget.cpp
@@ -76,7 +76,10 @@ namespace Editor {
         Engine::MainClass::GetInstance()->GetRenderSystem()->SetActiveCamera(
             Engine::MainClass::GetInstance()->GetWorldSystem()->m_active_camera
         );
-        Engine::MainClass::GetInstance()->GetRenderSystem()->DrawMeshes();
+        cb.DrawRenderers(
+            Engine::MainClass::GetInstance()->GetRenderSystem()->GetRendererManager().FilterAndSortRenderers({}),
+            0
+        );
         cb.EndRendering();
     }
 

--- a/editor/Editor/Widget/SceneWidget.cpp
+++ b/editor/Editor/Widget/SceneWidget.cpp
@@ -91,10 +91,12 @@ namespace Editor {
             m_render_target_binding, {(uint32_t)m_viewport_size.x, (uint32_t)m_viewport_size.y}, "Editor Scene Pass"
         );
         Engine::MainClass::GetInstance()->GetRenderSystem()->SetActiveCamera(m_camera.m_camera);
-        Engine::MainClass::GetInstance()->GetRenderSystem()->DrawMeshes(
+        cb.DrawRenderers(
+            Engine::MainClass::GetInstance()->GetRenderSystem()->GetRendererManager().FilterAndSortRenderers({}),
             m_camera.m_camera->GetViewMatrix(),
             m_camera.m_camera->GetProjectionMatrix(),
-            {(uint32_t)m_viewport_size.x, (uint32_t)m_viewport_size.y}
+            {(uint32_t)m_viewport_size.x, (uint32_t)m_viewport_size.y},
+            0
         );
         cb.EndRendering();
     }

--- a/engine/Asset/Loader/ObjLoader.cpp
+++ b/engine/Asset/Loader/ObjLoader.cpp
@@ -166,7 +166,7 @@ namespace Engine {
                             }
                         }
                     );
-                    VertexStruct::VertexAttribute attr = {};
+                    VertexStruct::VertexAttributeBasic attr = {};
                     if (colors.size() > 0) {
                         attr.color[0] = colors[index.vertex_index * 3];
                         attr.color[1] = colors[index.vertex_index * 3 + 1];
@@ -181,7 +181,7 @@ namespace Engine {
                         attr.texcoord1[0] = uvs[index.texcoord_index * 2];
                         attr.texcoord1[1] = uvs[index.texcoord_index * 2 + 1];
                     }
-                    submesh.m_attributes.push_back(attr);
+                    submesh.m_attributes_basic.push_back(attr);
                 }
                 submesh.m_indices.push_back(vertex_id_map[key]);
             }

--- a/engine/Asset/Mesh/MeshAsset.cpp
+++ b/engine/Asset/Mesh/MeshAsset.cpp
@@ -27,11 +27,17 @@ namespace Engine {
             ret += GetSubmeshVertexCount(submesh_idx) * sizeof(VertexStruct::VertexAttributeBasic);
         }
         if (!m_submeshes[submesh_idx].m_attributes_extended.empty()) {
-            assert(m_submeshes[submesh_idx].m_attributes_extended.size() == m_submeshes[submesh_idx].m_attributes_basic.size());
+            assert(
+                m_submeshes[submesh_idx].m_attributes_extended.size()
+                == m_submeshes[submesh_idx].m_attributes_basic.size()
+            );
             ret += GetSubmeshVertexCount(submesh_idx) * sizeof(VertexStruct::VertexAttributeExtended);
         }
         if (!m_submeshes[submesh_idx].m_attributes_skinned.empty()) {
-            assert(m_submeshes[submesh_idx].m_attributes_skinned.size() == m_submeshes[submesh_idx].m_attributes_basic.size());
+            assert(
+                m_submeshes[submesh_idx].m_attributes_skinned.size()
+                == m_submeshes[submesh_idx].m_attributes_basic.size()
+            );
             ret += GetSubmeshVertexCount(submesh_idx) * sizeof(VertexStruct::VertexAttributeSkinned);
         }
         return ret;

--- a/engine/Asset/Mesh/MeshAsset.h
+++ b/engine/Asset/Mesh/MeshAsset.h
@@ -23,12 +23,16 @@ namespace Engine
         {
             std::vector<uint32_t> m_indices{};
             std::vector<VertexStruct::VertexPosition> m_positions{};
-            std::vector<VertexStruct::VertexAttribute> m_attributes{};
+            std::vector<VertexStruct::VertexAttributeBasic> m_attributes_basic{};
+            std::vector<VertexStruct::VertexAttributeExtended> m_attributes_extended{};
+            std::vector<VertexStruct::VertexAttributeSkinned> m_attributes_skinned{};
         };
 
         REFL_ENABLE size_t GetSubmeshCount() const;
         REFL_ENABLE uint32_t GetSubmeshVertexIndexCount(size_t submesh_idx) const;
         REFL_ENABLE uint32_t GetSubmeshVertexCount(size_t submesh_idx) const;
+
+        [[deprecated("Expected buffer size is calculated by HomogeneousMesh instead.")]]
         REFL_ENABLE uint64_t GetSubmeshExpectedBufferSize(size_t submesh_idx) const;
 
         virtual void save_asset_to_archive(Serialization::Archive &archive) const override;

--- a/engine/Core/flagbits.h
+++ b/engine/Core/flagbits.h
@@ -5,13 +5,11 @@
 #include <initializer_list>
 
 namespace Engine {
-    template<class T>
-    concept IsEnum = std::is_enum<T>::value;
     /**
      * @brief Type-safe bit flag to be used with scoped or unscoped enums.
      * Maybe we can directly use vk::Flags and avoid re-inventing the wheels...
      */
-    template <class T> requires IsEnum<T>
+    template <class T> requires std::is_enum_v<T>
     class Flags {
         using UnderlyingType = std::underlying_type_t<T>;
         UnderlyingType m_flags;
@@ -41,62 +39,78 @@ namespace Engine {
             return m_flags;
         }
 
-        constexpr operator bool() const {
+        /// @brief Check whether any flag is set.
+        constexpr operator bool() const noexcept {
             return m_flags != static_cast<UnderlyingType>(0);
         }
 
-        friend constexpr Flags operator|(Flags lhs, T rhs) {
+        /// @brief Set a specific bit to be true.
+        constexpr void Set(T bit) noexcept {
+            m_flags |= static_cast<UnderlyingType>(bit);
+        }
+
+        /// @brief Test whether a bit (or any of the given bits) is set.
+        constexpr bool Test(T bit) const noexcept {
+            return static_cast<bool>(m_flags & static_cast<UnderlyingType>(bit));
+        }
+
+        /// @brief Mask the current flag with given bits.
+        constexpr void Mask(T bit) noexcept {
+            m_flags &= static_cast<UnderlyingType>(bit);
+        }
+
+        friend constexpr Flags operator|(Flags lhs, T rhs) noexcept {
             return Flags(lhs.m_flags | static_cast<UnderlyingType>(rhs));
         }
-        friend constexpr Flags operator|(Flags lhs, Flags rhs) {
+        friend constexpr Flags operator|(Flags lhs, Flags rhs) noexcept {
             return Flags(lhs.m_flags | rhs.m_flags);
         }
-        friend constexpr Flags operator&(Flags lhs, T rhs) {
+        friend constexpr Flags operator&(Flags lhs, T rhs) noexcept {
             return Flags(lhs.m_flags & static_cast<UnderlyingType>(rhs));
         }
-        friend constexpr Flags operator&(Flags lhs, Flags rhs) {
+        friend constexpr Flags operator&(Flags lhs, Flags rhs) noexcept {
             return Flags(lhs.m_flags & rhs.m_flags);
         }
-        friend constexpr Flags operator^(Flags lhs, T rhs) {
+        friend constexpr Flags operator^(Flags lhs, T rhs) noexcept {
             return Flags(lhs.m_flags ^ static_cast<UnderlyingType>(rhs));
         }
-        friend constexpr Flags operator^(Flags lhs, Flags rhs) {
+        friend constexpr Flags operator^(Flags lhs, Flags rhs) noexcept {
             return Flags(lhs.m_flags ^ rhs.m_flags);
         }
 
-        friend constexpr Flags& operator|=(Flags& lhs, T rhs) {
+        friend constexpr Flags& operator|=(Flags& lhs, T rhs) noexcept {
             lhs.m_flags |= static_cast<UnderlyingType>(rhs);
             return lhs;
         }
-        friend constexpr Flags& operator|=(Flags& lhs, Flags rhs) {
+        friend constexpr Flags& operator|=(Flags& lhs, Flags rhs) noexcept {
             lhs.m_flags |= rhs.m_flags;
             return lhs;
         }
-        friend constexpr Flags& operator&=(Flags& lhs, T rhs) {
+        friend constexpr Flags& operator&=(Flags& lhs, T rhs) noexcept {
             lhs.m_flags &= static_cast<UnderlyingType>(rhs);
             return lhs;
         }
-        friend constexpr Flags& operator&=(Flags& lhs, Flags rhs) {
+        friend constexpr Flags& operator&=(Flags& lhs, Flags rhs) noexcept {
             lhs.m_flags &= rhs.m_flags;
             return lhs;
         }
-        friend constexpr Flags& operator^=(Flags& lhs, T rhs) {
+        friend constexpr Flags& operator^=(Flags& lhs, T rhs) noexcept {
             lhs.m_flags ^= static_cast<UnderlyingType>(rhs);
             return lhs;
         }
-        friend constexpr Flags& operator^=(Flags& lhs, Flags rhs) {
+        friend constexpr Flags& operator^=(Flags& lhs, Flags rhs) noexcept {
             lhs.m_flags ^= rhs.m_flags;
             return lhs;
         }
 
-        friend constexpr Flags operator~(const Flags& bf) {
+        friend constexpr Flags operator~(const Flags& bf) noexcept {
             return Flags(~bf.m_flags);
         }
 
-        friend constexpr bool operator==(const Flags& lhs, const Flags& rhs) {
+        friend constexpr bool operator==(const Flags& lhs, const Flags& rhs) noexcept {
             return lhs.m_flags == rhs.m_flags;
         }
-        friend constexpr bool operator!=(const Flags& lhs, const Flags& rhs) {
+        friend constexpr bool operator!=(const Flags& lhs, const Flags& rhs) noexcept {
             return lhs.m_flags != rhs.m_flags;
         }
 

--- a/engine/Core/flagbits.h
+++ b/engine/Core/flagbits.h
@@ -1,0 +1,106 @@
+#ifndef CORE_FLAGBITS
+#define CORE_FLAGBITS
+
+#include <type_traits>
+#include <initializer_list>
+
+namespace Engine {
+    template<class T>
+    concept IsEnum = std::is_enum<T>::value;
+    /**
+     * @brief Type-safe bit flag to be used with scoped or unscoped enums.
+     * Maybe we can directly use vk::Flags and avoid re-inventing the wheels...
+     */
+    template <class T> requires IsEnum<T>
+    class Flags {
+        using UnderlyingType = std::underlying_type_t<T>;
+        UnderlyingType m_flags;
+
+    public:
+        /// @brief Default constructor with no bit set.
+        constexpr Flags() : m_flags(static_cast<UnderlyingType>(0)) {
+        }
+
+        /// @brief Construct a flag with a single bit set.
+        constexpr explicit Flags(T bit) : m_flags(static_cast<UnderlyingType>(bit)) {
+        }
+
+        /// @brief Construct a flag with multiple bits set.
+        constexpr Flags(std::initializer_list<T> bits) : Flags() {
+            for (T b : bits) {
+                m_flags |= static_cast<UnderlyingType>(b);
+            }
+        }
+
+        /// @brief Construct a flag from underlying integer.
+        constexpr explicit Flags(UnderlyingType bits) : m_flags(bits) {
+        }
+
+        /// @brief Convert to the underlying integer type.
+        constexpr explicit operator UnderlyingType () {
+            return m_flags;
+        }
+
+        constexpr operator bool() const {
+            return m_flags != static_cast<UnderlyingType>(0);
+        }
+
+        friend constexpr Flags operator|(Flags lhs, T rhs) {
+            return Flags(lhs.m_flags | static_cast<UnderlyingType>(rhs));
+        }
+        friend constexpr Flags operator|(Flags lhs, Flags rhs) {
+            return Flags(lhs.m_flags | rhs.m_flags);
+        }
+        friend constexpr Flags operator&(Flags lhs, T rhs) {
+            return Flags(lhs.m_flags & static_cast<UnderlyingType>(rhs));
+        }
+        friend constexpr Flags operator&(Flags lhs, Flags rhs) {
+            return Flags(lhs.m_flags & rhs.m_flags);
+        }
+        friend constexpr Flags operator^(Flags lhs, T rhs) {
+            return Flags(lhs.m_flags ^ static_cast<UnderlyingType>(rhs));
+        }
+        friend constexpr Flags operator^(Flags lhs, Flags rhs) {
+            return Flags(lhs.m_flags ^ rhs.m_flags);
+        }
+
+        friend constexpr Flags& operator|=(Flags& lhs, T rhs) {
+            lhs.m_flags |= static_cast<UnderlyingType>(rhs);
+            return lhs;
+        }
+        friend constexpr Flags& operator|=(Flags& lhs, Flags rhs) {
+            lhs.m_flags |= rhs.m_flags;
+            return lhs;
+        }
+        friend constexpr Flags& operator&=(Flags& lhs, T rhs) {
+            lhs.m_flags &= static_cast<UnderlyingType>(rhs);
+            return lhs;
+        }
+        friend constexpr Flags& operator&=(Flags& lhs, Flags rhs) {
+            lhs.m_flags &= rhs.m_flags;
+            return lhs;
+        }
+        friend constexpr Flags& operator^=(Flags& lhs, T rhs) {
+            lhs.m_flags ^= static_cast<UnderlyingType>(rhs);
+            return lhs;
+        }
+        friend constexpr Flags& operator^=(Flags& lhs, Flags rhs) {
+            lhs.m_flags ^= rhs.m_flags;
+            return lhs;
+        }
+
+        friend constexpr Flags operator~(const Flags& bf) {
+            return Flags(~bf.m_flags);
+        }
+
+        friend constexpr bool operator==(const Flags& lhs, const Flags& rhs) {
+            return lhs.m_flags == rhs.m_flags;
+        }
+        friend constexpr bool operator!=(const Flags& lhs, const Flags& rhs) {
+            return lhs.m_flags != rhs.m_flags;
+        }
+
+    };
+}
+
+#endif // CORE_FLAGBITS

--- a/engine/Framework/component/RenderComponent/MeshComponent.cpp
+++ b/engine/Framework/component/RenderComponent/MeshComponent.cpp
@@ -30,10 +30,10 @@ namespace Engine {
         }
 
         // Commit vertex buffer to GPU
-        for (auto &submesh : m_submeshes) {
+        /* for (auto &submesh : m_submeshes) {
             submesh->Prepare();
             m_system.lock()->GetFrameManager().GetSubmissionHelper().EnqueueVertexBufferSubmission(*submesh);
-        }
+        } */
     }
 
     void MeshComponent::Tick() {

--- a/engine/Framework/component/RenderComponent/MeshComponent.cpp
+++ b/engine/Framework/component/RenderComponent/MeshComponent.cpp
@@ -18,6 +18,10 @@ namespace Engine {
         return m_submeshes;
     }
 
+    auto MeshComponent::GetSubmeshes() const -> const decltype(m_submeshes) & {
+        return m_submeshes;
+    }
+
     void MeshComponent::RenderInit() {
         RendererComponent::RenderInit();
 

--- a/engine/Framework/component/RenderComponent/MeshComponent.cpp
+++ b/engine/Framework/component/RenderComponent/MeshComponent.cpp
@@ -32,12 +32,6 @@ namespace Engine {
         for (size_t i = 0; i < submesh_count; i++) {
             m_submeshes.push_back(std::make_shared<HomogeneousMesh>(m_system, m_mesh_asset, i));
         }
-
-        // Commit vertex buffer to GPU
-        /* for (auto &submesh : m_submeshes) {
-            submesh->Prepare();
-            m_system.lock()->GetFrameManager().GetSubmissionHelper().EnqueueVertexBufferSubmission(*submesh);
-        } */
     }
 
     void MeshComponent::Tick() {

--- a/engine/Framework/component/RenderComponent/MeshComponent.h
+++ b/engine/Framework/component/RenderComponent/MeshComponent.h
@@ -21,6 +21,7 @@ namespace Engine
 
         std::shared_ptr<HomogeneousMesh> GetSubmesh(uint32_t slot) const;
         auto GetSubmeshes() -> decltype(m_submeshes) &;
+        auto GetSubmeshes() const -> const decltype(m_submeshes) &;
 
         /// @brief Materialize a runtime mesh component from a mesh asset
         virtual void RenderInit() override;

--- a/engine/Framework/component/RenderComponent/RendererComponent.cpp
+++ b/engine/Framework/component/RenderComponent/RendererComponent.cpp
@@ -24,7 +24,9 @@ namespace Engine {
         auto system = m_system.lock();
 
         // We should do some check maybe to avoid repetition.
-        system->GetRendererManager().RegisterRendererComponent(std::dynamic_pointer_cast<RendererComponent>(shared_from_this()));
+        system->GetRendererManager().RegisterRendererComponent(
+            std::dynamic_pointer_cast<RendererComponent>(shared_from_this())
+        );
 
         for (size_t i = 0; i < m_material_assets.size(); i++) {
             // XXX: This is a temporary solution: It simply check the m_name in material assets and add it to the

--- a/engine/Framework/component/RenderComponent/RendererComponent.cpp
+++ b/engine/Framework/component/RenderComponent/RendererComponent.cpp
@@ -1,6 +1,7 @@
 #include "RendererComponent.h"
 #include "Render/RenderSystem.h"
 #include "Render/RenderSystem/MaterialRegistry.h"
+#include "Render/RenderSystem/RendererManager.h"
 #include <Asset/Material/MaterialAsset.h>
 #include <Framework/component/RenderComponent/CameraComponent.h>
 #include <Framework/object/GameObject.h>
@@ -21,6 +22,9 @@ namespace Engine {
     void RendererComponent::RenderInit() {
         m_system = MainClass::GetInstance()->GetRenderSystem();
         auto system = m_system.lock();
+
+        // We should do some check maybe to avoid repetition.
+        system->GetRendererManager().RegisterRendererComponent(std::dynamic_pointer_cast<RendererComponent>(shared_from_this()));
 
         for (size_t i = 0; i < m_material_assets.size(); i++) {
             // XXX: This is a temporary solution: It simply check the m_name in material assets and add it to the
@@ -51,6 +55,10 @@ namespace Engine {
     }
 
     auto RendererComponent::GetMaterials() -> decltype(m_materials) & {
+        return m_materials;
+    }
+
+    auto RendererComponent::GetMaterials() const -> const decltype(m_materials) & {
         return m_materials;
     }
 } // namespace Engine

--- a/engine/Framework/component/RenderComponent/RendererComponent.cpp
+++ b/engine/Framework/component/RenderComponent/RendererComponent.cpp
@@ -21,7 +21,6 @@ namespace Engine {
     void RendererComponent::RenderInit() {
         m_system = MainClass::GetInstance()->GetRenderSystem();
         auto system = m_system.lock();
-        system->RegisterComponent(std::dynamic_pointer_cast<RendererComponent>(shared_from_this()));
 
         for (size_t i = 0; i < m_material_assets.size(); i++) {
             // XXX: This is a temporary solution: It simply check the m_name in material assets and add it to the

--- a/engine/Framework/component/RenderComponent/RendererComponent.h
+++ b/engine/Framework/component/RenderComponent/RendererComponent.h
@@ -37,6 +37,14 @@ namespace Engine
         auto GetMaterials() -> decltype(m_materials) &;
 
         REFL_SER_ENABLE std::vector<std::shared_ptr<AssetRef>> m_material_assets{};
+        /// @brief Is this renderer eagerly loaded onto the GPU instead of loaded on use?
+        REFL_SER_ENABLE bool m_is_eagerly_loaded{false};
+        /// @brief Do this renderer cast shadow (viz. rendered onto shadowmaps)?
+        REFL_SER_ENABLE bool m_cast_shadow{false};
+        /// @brief Bits of the layers of the renderer (eg. opaque, transparent or HUD).
+        REFL_SER_ENABLE uint32_t m_layer{0xFFFFFFFF};
+        /// @brief Currently unused.
+        REFL_SER_ENABLE uint32_t m_priority{0};
     };
 }
 #endif // FRAMEWORK_COMPONENT_RENDERCOMPONENT_RENDERERCOMPONENT_INCLUDED

--- a/engine/Framework/component/RenderComponent/RendererComponent.h
+++ b/engine/Framework/component/RenderComponent/RendererComponent.h
@@ -35,6 +35,7 @@ namespace Engine
 
         std::shared_ptr<MaterialInstance> GetMaterial(uint32_t slot) const;
         auto GetMaterials() -> decltype(m_materials) &;
+        auto GetMaterials() const -> const decltype(m_materials) &;
 
         REFL_SER_ENABLE std::vector<std::shared_ptr<AssetRef>> m_material_assets{};
         /// @brief Is this renderer eagerly loaded onto the GPU instead of loaded on use?

--- a/engine/MainClass.cpp
+++ b/engine/MainClass.cpp
@@ -3,17 +3,12 @@
 #include "Asset/AssetManager/AssetManager.h"
 #include "Framework/world/WorldSystem.h"
 #include "GUI/GUISystem.h"
-#include "Render/RenderSystem.h"
 #include <Asset/Scene/LevelAsset.h>
 #include <Functional/EventQueue.h>
 #include <Functional/SDLWindow.h>
 #include <Functional/Time.h>
 #include <Input/Input.h>
-#include <Render/Memory/Buffer.h>
-#include <Render/Memory/Texture.h>
-#include <Render/Pipeline/CommandBuffer.h>
-#include <Render/Pipeline/CommandBuffer/GraphicsContext.h>
-#include <Render/RenderSystem/FrameManager.h>
+#include <Render/FullRenderSystem.h>
 
 #include <exception>
 #include <fstream>
@@ -82,7 +77,6 @@ namespace Engine {
         }
         SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "The main loop is ended.");
         renderer->WaitForIdle();
-        renderer->ClearComponent();
     }
 
     void MainClass::LoopFinite(uint64_t max_frame_count, float max_time_seconds) {
@@ -94,7 +88,6 @@ namespace Engine {
         }
         SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "The main loop is ended.");
         renderer->WaitForIdle();
-        renderer->ClearComponent();
     }
 
     std::shared_ptr<SDLWindow> MainClass::GetWindow() const {
@@ -175,7 +168,7 @@ namespace Engine {
         context.PrepareCommandBuffer();
         cb.BeginRendering(this->window->GetRenderTargetBinding(), this->window->GetExtent(), "Main Pass");
         this->renderer->SetActiveCamera(this->world->m_active_camera);
-        this->renderer->DrawMeshes();
+        cb.DrawRenderers(renderer->GetRendererManager().FilterAndSortRenderers({}), 0);
         cb.EndRendering();
 
         // context.UseImage(this->window->GetColorTexture(),

--- a/engine/Render/FullRenderSystem.h
+++ b/engine/Render/FullRenderSystem.h
@@ -13,6 +13,7 @@
 #include "Render/RenderSystem/SubmissionHelper.h"
 #include "Render/RenderSystem/GlobalConstantDescriptorPool.h"
 #include "Render/RenderSystem/MaterialRegistry.h"
+#include "Render/RenderSystem/RendererManager.h"
 
 #include "Render/Pipeline/CommandBuffer.h"
 #include "Render/Pipeline/CommandBuffer/GraphicsContext.h"

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
@@ -7,7 +7,6 @@
 #include "Render/Pipeline/Material/MaterialInstance.h"
 #include "Render/Pipeline/RenderTargetBinding.h"
 #include "Render/RenderSystem/GlobalConstantDescriptorPool.h"
-#include "Render/RenderSystem/RendererManager.h"
 #include "Render/RenderSystem/FrameManager.h"
 #include "Render/RenderSystem/Swapchain.h"
 #include "Render/Renderer/HomogeneousMesh.h"

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
@@ -200,12 +200,15 @@ namespace Engine {
             glm::mat4 model_matrix = component->GetWorldTransform().GetTransformMatrix();
 
             const auto &materials = component->GetMaterials();
-            const auto &meshes = component->GetSubmeshes();
 
-            assert(materials.size() == meshes.size());
-            for (size_t id = 0; id < materials.size(); id++) {
-                this->BindMaterial(*materials[id], pass);
-                this->DrawMesh(*meshes[id], model_matrix);
+            if (auto mesh_ptr = dynamic_cast<const MeshComponent *>(component)) {
+                const auto &meshes = mesh_ptr->GetSubmeshes();
+
+                assert(materials.size() == meshes.size());
+                for (size_t id = 0; id < materials.size(); id++) {
+                    this->BindMaterial(*materials[id], pass);
+                    this->DrawMesh(*meshes[id], model_matrix);
+                }
             }
         }
     }

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
@@ -6,11 +6,11 @@
 #include "Render/Memory/Buffer.h"
 #include "Render/Pipeline/Material/MaterialInstance.h"
 #include "Render/Pipeline/RenderTargetBinding.h"
-#include "Render/RenderSystem/GlobalConstantDescriptorPool.h"
 #include "Render/RenderSystem/FrameManager.h"
+#include "Render/RenderSystem/GlobalConstantDescriptorPool.h"
 #include "Render/RenderSystem/Swapchain.h"
-#include "Render/Renderer/HomogeneousMesh.h"
 #include "Render/Renderer/Camera.h"
+#include "Render/Renderer/HomogeneousMesh.h"
 
 #include "Render/DebugUtils.h"
 #include "Render/Pipeline/CommandBuffer/LayoutTransferHelper.h"
@@ -153,7 +153,7 @@ namespace Engine {
 
     void GraphicsCommandBuffer::DrawMesh(const HomogeneousMesh &mesh, const glm::mat4 &model_matrix) {
         auto bindings = mesh.GetVertexBufferInfo();
-        std::vector <vk::Buffer> vertex_buffers{bindings.second.size(), bindings.first};
+        std::vector<vk::Buffer> vertex_buffers{bindings.second.size(), bindings.first};
         cb.bindVertexBuffers(0, vertex_buffers, bindings.second);
         auto indices = mesh.GetIndexBufferInfo();
         cb.bindIndexBuffer(indices.first, indices.second, vk::IndexType::eUint32);
@@ -172,11 +172,7 @@ namespace Engine {
         auto camera = m_system.GetActiveCamera().lock();
         assert(camera);
         this->DrawRenderers(
-            renderers, 
-            camera->GetViewMatrix(), 
-            camera->GetProjectionMatrix(), 
-            m_system.GetSwapchain().GetExtent(), 
-            pass
+            renderers, camera->GetViewMatrix(), camera->GetProjectionMatrix(), m_system.GetSwapchain().GetExtent(), pass
         );
     }
 
@@ -196,8 +192,8 @@ namespace Engine {
 
         vk::Rect2D scissor{{0, 0}, extent};
         this->SetupViewport(extent.width, extent.height, scissor);
-        for (const auto & rid : renderers) {
-            const auto & component = m_system.GetRendererManager().GetRendererData(rid);
+        for (const auto &rid : renderers) {
+            const auto &component = m_system.GetRendererManager().GetRendererData(rid);
             glm::mat4 model_matrix = component->GetWorldTransform().GetTransformMatrix();
 
             const auto &materials = component->GetMaterials();

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
@@ -152,9 +152,10 @@ namespace Engine {
     }
 
     void GraphicsCommandBuffer::DrawMesh(const HomogeneousMesh &mesh, const glm::mat4 &model_matrix) {
-        auto bindings = mesh.GetBindingInfo();
-        cb.bindVertexBuffers(0, bindings.first, bindings.second);
-        auto indices = mesh.GetIndexInfo();
+        auto bindings = mesh.GetVertexBufferInfo();
+        std::vector <vk::Buffer> vertex_buffers{bindings.second.size(), bindings.first};
+        cb.bindVertexBuffers(0, vertex_buffers, bindings.second);
+        auto indices = mesh.GetIndexBufferInfo();
         cb.bindIndexBuffer(indices.first, indices.second, vk::IndexType::eUint32);
 
         cb.pushConstants(
@@ -219,12 +220,7 @@ namespace Engine {
     }
 
     void GraphicsCommandBuffer::DrawMesh(const HomogeneousMesh &mesh) {
-        auto bindings = mesh.GetBindingInfo();
-        cb.bindVertexBuffers(0, bindings.first, bindings.second);
-        auto indices = mesh.GetIndexInfo();
-        cb.bindIndexBuffer(indices.first, indices.second, vk::IndexType::eUint32);
-
-        cb.drawIndexed(mesh.GetVertexIndexCount(), 1, 0, 0, 0);
+        this->DrawMesh(mesh, glm::mat4{1.0f});
     }
 
     void GraphicsCommandBuffer::Reset() noexcept {

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
@@ -13,6 +13,7 @@ namespace Engine {
     class HomogeneousMesh;
     class Buffer;
     class RenderTargetBinding;
+    class RendererList;
 
     /**
      * @brief A command buffer used for rendering.
@@ -71,7 +72,10 @@ namespace Engine {
         /// @brief Write per-mesh descriptors, and send draw call to GPU.
         /// @param mesh 
         void DrawMesh(const HomogeneousMesh & mesh);
-        void DrawMesh(const HomogeneousMesh& mesh, const glm::mat4 & model_matrix);
+        void DrawMesh(const HomogeneousMesh & mesh, const glm::mat4 & model_matrix);
+
+        void DrawRenderers (const RendererList & renderers, uint32_t pass);
+        void DrawRenderers (const RendererList & renderers, const glm::mat4 &view_matrix, const glm::mat4 &projection_matrix, vk::Extent2D extent, uint32_t pass);
 
         /// @brief End the render pass
         void EndRendering();

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
@@ -1,8 +1,9 @@
-#ifndef PIPELINE_COMMANDBUFFER_GraphicsCommandBuffer_INCLUDED
-#define PIPELINE_COMMANDBUFFER_GraphicsCommandBuffer_INCLUDED
+#ifndef PIPELINE_COMMANDBUFFER_GRAPHICSCOMMANDBUFFER_INCLUDED
+#define PIPELINE_COMMANDBUFFER_GRAPHICSCOMMANDBUFFER_INCLUDED
 
 #include "Render/VkWrapper.tcc"
 #include "Render/AttachmentUtils.h"
+#include "Render/RenderSystem/RendererManager.h"
 #include "Render/Pipeline/CommandBuffer/TransferCommandBuffer.h"
 #include <vulkan/vulkan.hpp>
 #include <glm.hpp>
@@ -13,7 +14,6 @@ namespace Engine {
     class HomogeneousMesh;
     class Buffer;
     class RenderTargetBinding;
-    class RendererList;
 
     /**
      * @brief A command buffer used for rendering.
@@ -88,4 +88,4 @@ namespace Engine {
     };
 }
 
-#endif // PIPELINE_COMMANDBUFFER_GraphicsCommandBuffer_INCLUDED
+#endif // PIPELINE_COMMANDBUFFER_GRAPHICSCOMMANDBUFFER_INCLUDED

--- a/engine/Render/Pipeline/Material/MaterialTemplate.cpp
+++ b/engine/Render/Pipeline/Material/MaterialTemplate.cpp
@@ -165,10 +165,12 @@ namespace Engine {
             vk::ClearValue{vk::ClearDepthStencilValue{1.0f, 0u}}
         };
 
+        std::vector<vk::Format> color_attachment_formats{prop.attachments.color.size(), vk::Format::eUndefined};
         // Fill in attachment information
         if (use_swapchain_attachments) {
+            color_attachment_formats = {default_color_format};
             prci = vk::PipelineRenderingCreateInfo{
-                0, {default_color_format}, default_depth_format, vk::Format::eUndefined
+                0, color_attachment_formats, default_depth_format, vk::Format::eUndefined
             };
             cbass.push_back(
                 vk::PipelineColorBlendAttachmentState{
@@ -207,7 +209,6 @@ namespace Engine {
                 && "Mismatched color attachment and blending operation size."
             );
 
-            std::vector<vk::Format> color_attachment_formats{prop.attachments.color.size(), vk::Format::eUndefined};
             pass_info.attachments.color_attachment_ops.resize(prop.attachments.color_ops.size());
             cbass.resize(prop.attachments.color_blending.size());
 

--- a/engine/Render/RenderSystem.cpp
+++ b/engine/Render/RenderSystem.cpp
@@ -15,6 +15,7 @@
 #include "Render/RenderSystem/MaterialRegistry.h"
 #include "Render/RenderSystem/PhysicalDevice.h"
 #include "Render/RenderSystem/Swapchain.h"
+#include "Render/RenderSystem/RendererManager.h"
 #include "Render/Renderer/Camera.h"
 #include "Render/Renderer/HomogeneousMesh.h"
 
@@ -29,7 +30,7 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 namespace Engine {
     struct RenderSystem::impl {
         impl(RenderSystem &parent, std::weak_ptr<SDLWindow> parent_window) :
-            m_window(parent_window), m_allocator_state(parent), m_frame_manager(parent) {
+            m_window(parent_window), m_allocator_state(parent), m_frame_manager(parent), m_renderer_manager(parent) {
 
             };
 
@@ -51,8 +52,7 @@ namespace Engine {
         // uint32_t m_in_flight_frame_id = 0;
 
         std::weak_ptr<SDLWindow> m_window;
-        // TODO: data: mesh, texture, light
-        std::vector<std::shared_ptr<RendererComponent>> m_components{};
+
         std::weak_ptr<Camera> m_active_camera{};
 
         RenderSystemState::PhysicalDevice m_selected_physical_device{};
@@ -70,6 +70,7 @@ namespace Engine {
         RenderSystemState::FrameManager m_frame_manager;
         RenderSystemState::GlobalConstantDescriptorPool m_descriptor_pool{};
         RenderSystemState::MaterialRegistry m_material_registry{};
+        RenderSystemState::RendererManager m_renderer_manager;
     };
 
     RenderSystem::RenderSystem(std::weak_ptr<SDLWindow> parent_window) {
@@ -106,58 +107,12 @@ namespace Engine {
         std::cerr << "Render system deconstructed" << std::endl;
     }
 
-    void RenderSystem::DrawMeshes(uint32_t pass) {
-        glm::mat4 view{1.0f}, proj{1.0f};
-        auto camera = pimpl->m_active_camera.lock();
-        if (camera) {
-            view = camera->GetViewMatrix();
-            proj = camera->GetProjectionMatrix();
-        }
-        DrawMeshes(view, proj, this->GetSwapchain().GetExtent(), pass);
-    }
-
-    void RenderSystem::DrawMeshes(
-        const glm::mat4 &view_matrix, const glm::mat4 &projection_matrix, vk::Extent2D extent, uint32_t pass
-    ) {
-        GraphicsCommandBuffer cb = this->GetFrameManager().GetCommandBuffer();
-
-        // Write camera transforms
-        auto camera_ptr = this->GetGlobalConstantDescriptorPool().GetPerCameraConstantMemory(
-            pimpl->m_frame_manager.GetFrameInFlight(), GetActiveCameraId()
-        );
-        ConstantData::PerCameraStruct camera_struct{view_matrix, projection_matrix};
-        std::memcpy(camera_ptr, &camera_struct, sizeof camera_struct);
-
-        vk::Rect2D scissor{{0, 0}, extent};
-        cb.SetupViewport(extent.width, extent.height, scissor);
-        for (const auto &component : pimpl->m_components) {
-            glm::mat4 model_matrix = component->GetWorldTransform().GetTransformMatrix();
-            auto down_casted_ptr = std::dynamic_pointer_cast<MeshComponent>(component);
-            if (down_casted_ptr == nullptr) {
-                continue;
-            }
-
-            const auto &materials = down_casted_ptr->GetMaterials();
-            const auto &meshes = down_casted_ptr->GetSubmeshes();
-
-            assert(materials.size() == meshes.size());
-            for (size_t id = 0; id < materials.size(); id++) {
-                cb.BindMaterial(*materials[id], pass);
-                cb.DrawMesh(*meshes[id], model_matrix);
-            }
-        }
-    }
-
-    void RenderSystem::RegisterComponent(std::shared_ptr<RendererComponent> comp) {
-        pimpl->m_components.push_back(comp);
-    }
-
-    void RenderSystem::ClearComponent() {
-        pimpl->m_components.clear();
-    }
-
     void RenderSystem::SetActiveCamera(std::weak_ptr<Camera> camera) {
         pimpl->m_active_camera = camera;
+    }
+
+    std::weak_ptr<Camera> RenderSystem::GetActiveCamera() const {
+        return pimpl->m_active_camera;
     }
 
     uint32_t RenderSystem::GetActiveCameraId() const {
@@ -199,6 +154,10 @@ namespace Engine {
 
     RenderSystemState::FrameManager &RenderSystem::GetFrameManager() {
         return pimpl->m_frame_manager;
+    }
+
+    RenderSystemState::RendererManager &RenderSystem::GetRendererManager() {
+        return pimpl->m_renderer_manager;
     }
 
     void RenderSystem::CompleteFrame() {

--- a/engine/Render/RenderSystem.cpp
+++ b/engine/Render/RenderSystem.cpp
@@ -14,8 +14,8 @@
 #include "Render/RenderSystem/MaterialDescriptorManager.h"
 #include "Render/RenderSystem/MaterialRegistry.h"
 #include "Render/RenderSystem/PhysicalDevice.h"
-#include "Render/RenderSystem/Swapchain.h"
 #include "Render/RenderSystem/RendererManager.h"
+#include "Render/RenderSystem/Swapchain.h"
 #include "Render/Renderer/Camera.h"
 #include "Render/Renderer/HomogeneousMesh.h"
 

--- a/engine/Render/RenderSystem.h
+++ b/engine/Render/RenderSystem.h
@@ -28,6 +28,7 @@ namespace Engine
         class GlobalConstantDescriptorPool;
         class MaterialRegistry;
         class FrameManager;
+        class RendererManager;
     };
 
     class RenderSystem : public std::enable_shared_from_this<RenderSystem>
@@ -60,23 +61,8 @@ namespace Engine
 
         ~RenderSystem();
 
-        /**
-         * @brief Draw meshes using the matrices of the active camera (identity matrices if default).
-         */
-        void DrawMeshes(uint32_t pass = 0);
-
-        /**
-         * @brief Draw meshes with the given view and projection matrices.
-         * 
-         * This method writes camera uniforms and viewport state.
-         * Then it binds materials and records draw calls on the current render command buffer.
-         */
-        void DrawMeshes(const glm::mat4 & view_matrix, const glm::mat4 & projection_matrix, vk::Extent2D extent, uint32_t pass = 0);
-        
-        void RegisterComponent(std::shared_ptr <RendererComponent>);
-        void ClearComponent();
-
         void SetActiveCamera(std::weak_ptr <Camera>);
+        std::weak_ptr <Camera> GetActiveCamera() const;
         uint32_t GetActiveCameraId() const;
         void WaitForIdle() const;
 
@@ -109,6 +95,8 @@ namespace Engine
         RenderSystemState::MaterialRegistry & GetMaterialRegistry();
 
         RenderSystemState::FrameManager & GetFrameManager ();
+
+        RenderSystemState::RendererManager & GetRendererManager ();
 
         void WritePerCameraConstants(const ConstantData::PerCameraStruct & data, uint32_t in_flight_index);
     };

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -308,7 +308,6 @@ namespace Engine::RenderSystemState {
     }
 
     uint32_t FrameManager::StartFrame(uint64_t timeout) {
-        pimpl->m_submission_helper->StartFrame();
 
         auto device = pimpl->m_system.getDevice();
         uint32_t fif = GetFrameInFlight();
@@ -341,6 +340,8 @@ namespace Engine::RenderSystemState {
     }
 
     void FrameManager::SubmitMainCommandBuffer() {
+        pimpl->m_submission_helper->ExecuteSubmission();
+
         bool wait_for_semaphore = (pimpl->total_frame_count > 0);
         uint32_t fif = GetFrameInFlight();
         vk::SubmitInfo info{};

--- a/engine/Render/RenderSystem/FrameManager.h
+++ b/engine/Render/RenderSystem/FrameManager.h
@@ -56,6 +56,7 @@ namespace Engine {
 
             /**
              * @brief Submit the main command buffer to the graphics queue for execution.
+             * Also performs staged resource submission.
              * 
              * @warning Must be called before either `CompositeToFramebufferAndPresent` or `CompositeToImage`, once each frame.
              * Non-standard call-sites are likely to result in deadlocks and vulkan device losses.

--- a/engine/Render/RenderSystem/RendererManager.cpp
+++ b/engine/Render/RenderSystem/RendererManager.cpp
@@ -1,10 +1,131 @@
 #include "RendererManager.h"
+#include "Render/RenderSystem.h"
+#include "Render/RenderSystem/FrameManager.h"
+#include "Render/RenderSystem/SubmissionHelper.h"
+#include "Framework/component/RenderComponent/MeshComponent.h"
+#include "Core/flagbits.h"
 
 namespace Engine {
     struct RendererManager::impl {
 
+        enum class StatusBits : uint32_t {
+            MemoryStatusMask = 0x0000FFFF,
+            RendererTypeMask = 0xFFFF0000,
+
+            // Submitted to GPU and ready for rendering.
+            Ready = 0b0000'0000'0000'0001,
+            // A submission is pending.
+            Pending = 0b0000'0000'0000'0010,
+            // Loaded to CPU memory from disk.
+            Loaded = 0b0000'0000'0000'0100,
+            // Eager submission requested.
+            Eager = 0b0000'0000'0000'1000,
+
+            // Slated for removal from the manager.
+            Removal = 0b0000'0000'1000'0000,
+
+            // This renderer cast shadows.
+            ShadowCaster = 0b0000'0001'0000'0000,
+        };
+        using StatusFlags = Flags<StatusBits>;
+
+        struct RendererControlBlock {
+            StatusFlags status{};
+            uint32_t layer{};
+        };
+
+        struct RendererDataBlock {
+            /// We will try to move data such as materials and buffers
+            /// from `MeshComponent` into this manager to form a ECS architecture.
+            /// For now we just save its pointer.
+            std::shared_ptr <MeshComponent> m_component;
+
+            // uint32_t renderer_idx;
+            // uint32_t material_idx;
+        };
+
+        std::vector <RendererControlBlock> m_status;
+        std::vector <RendererDataBlock> m_data;
+
+        // std::vector <HomogeneousMesh *> m_meshes;
+        // std::vector <MaterialInstance *> m_materials;
     };
-    RendererManager::RendererManager(RenderSystem & system) : m_system(system) {
+
+    RendererManager::RendererManager(RenderSystem & system) : m_system(system), pimpl(std::make_unique<impl>()) {
     }
     RendererManager::~RendererManager() = default;
-};
+
+    RendererHandle RendererManager::RegisterRendererComponent(std::shared_ptr<MeshComponent> component)
+    {   
+        impl::StatusFlags sflag{};
+        if (component->m_cast_shadow) sflag.Set(impl::StatusBits::ShadowCaster);
+        if (component->m_is_eagerly_loaded) sflag.Set(impl::StatusBits::Eager);
+        sflag.Set(impl::StatusBits::Loaded);
+
+        pimpl->m_status.push_back(impl::RendererControlBlock{.status = sflag, .layer = component->m_layer});
+        pimpl->m_data.push_back(impl::RendererDataBlock{component});
+        assert(pimpl->m_status.size() == pimpl->m_data.size());
+
+        return pimpl->m_data.size() - 1;
+    }
+    void RendererManager::UnregisterRendererComponent(RendererHandle handle) {
+        assert(handle < pimpl->m_status.size());
+        pimpl->m_status[handle].status.Set(impl::StatusBits::Removal);
+    }
+    void RendererManager::UpdateRendererStates() {
+        assert(pimpl->m_status.size() == pimpl->m_data.size());
+
+        for (size_t i = 0; i < pimpl->m_status.size(); i++) {
+            auto & s = pimpl->m_status[i].status;
+
+            if (s.Test(impl::StatusBits::Removal)) {
+                pimpl->m_data[i].m_component.reset();
+                break;
+            }
+
+            if (s.Test(impl::StatusBits::Eager) && !s.Test(impl::StatusBits::Loaded)) {
+                s.Set(impl::StatusBits::Loaded);
+
+                for (auto mesh : pimpl->m_data[i].m_component->GetSubmeshes()) {
+                    m_system.GetFrameManager().GetSubmissionHelper().EnqueueVertexBufferSubmission(*mesh);
+                }
+            }
+        }
+    }
+    void RendererManager::ClearUnregisteredRendererComponent() {
+        assert(!"Unimplemented");
+    }
+    RendererList RendererManager::FilterAndSortRenderers(FilterCriteria fc, SortingCriterion sc) {
+        assert(sc == SortingCriterion::None && "Unimplemented");
+        std::vector <uint32_t> ret{};
+
+        for (uint32_t i = 0; i < pimpl->m_status.size(); i++) {
+            
+            if ((fc.layer & pimpl->m_status[i].layer) == 0) continue;
+            if (fc.is_shadow_caster != FilterCriteria::BinaryCriterion::DontCare) {
+                auto shadow_caster = pimpl->m_status[i].status.Test(impl::StatusBits::ShadowCaster);
+                if (shadow_caster != static_cast<int>(fc.is_shadow_caster)) continue;
+            }
+
+            if (pimpl->m_status[i].status.Test(impl::StatusBits::Removal))  continue;
+
+            ret.push_back(i);
+            if (!pimpl->m_status[i].status.Test(impl::StatusBits::Loaded)) {
+                pimpl->m_status[i].status.Set(impl::StatusBits::Loaded);
+
+                for (auto mesh : pimpl->m_data[i].m_component->GetSubmeshes()) {
+                    m_system.GetFrameManager().GetSubmissionHelper().EnqueueVertexBufferSubmission(*mesh);
+                }
+            }
+        }
+
+        // TODO: Cache the result for better performace.
+        return ret;
+    }
+
+    MeshComponent *RendererManager::GetRendererData(RendererHandle handle) const noexcept {
+        assert(handle < pimpl->m_data.size());
+        assert(pimpl->m_data[handle].m_component);
+        return pimpl->m_data[handle].m_component.get();
+    }
+}; // namespace Engine

--- a/engine/Render/RenderSystem/RendererManager.cpp
+++ b/engine/Render/RenderSystem/RendererManager.cpp
@@ -93,7 +93,6 @@ namespace Engine::RenderSystemState {
                 SDL_LogDebug(SDL_LOG_CATEGORY_RENDER, "Eagerly loading component 0x%p", static_cast<void *>(pimpl->m_data[i].m_component.get()));
                 if (auto mesh_ptr = std::dynamic_pointer_cast<MeshComponent>(pimpl->m_data[i].m_component)) {
                     for (auto mesh : mesh_ptr->GetSubmeshes()) {
-                        mesh->Prepare();
                         m_system.GetFrameManager().GetSubmissionHelper().EnqueueVertexBufferSubmission(*mesh);
                     }
                 }
@@ -124,7 +123,6 @@ namespace Engine::RenderSystemState {
 
                 if (auto mesh_ptr = std::dynamic_pointer_cast<MeshComponent>(pimpl->m_data[i].m_component)) {
                     for (auto mesh : mesh_ptr->GetSubmeshes()) {
-                        mesh->Prepare();
                         m_system.GetFrameManager().GetSubmissionHelper().EnqueueVertexBufferSubmission(*mesh);
                     }
                 }

--- a/engine/Render/RenderSystem/RendererManager.cpp
+++ b/engine/Render/RenderSystem/RendererManager.cpp
@@ -5,7 +5,7 @@
 #include "Framework/component/RenderComponent/MeshComponent.h"
 #include "Core/flagbits.h"
 
-namespace Engine {
+namespace Engine::RenderSystemState {
     struct RendererManager::impl {
 
         enum class StatusBits : uint32_t {

--- a/engine/Render/RenderSystem/RendererManager.cpp
+++ b/engine/Render/RenderSystem/RendererManager.cpp
@@ -1,0 +1,10 @@
+#include "RendererManager.h"
+
+namespace Engine {
+    struct RendererManager::impl {
+
+    };
+    RendererManager::RendererManager(RenderSystem & system) : m_system(system) {
+    }
+    RendererManager::~RendererManager() = default;
+};

--- a/engine/Render/RenderSystem/RendererManager.h
+++ b/engine/Render/RenderSystem/RendererManager.h
@@ -16,7 +16,14 @@ namespace Engine {
     public:
 
         struct FilterCriteria {
-            uint32_t layer;
+            enum class BinaryCriterion : uint8_t {
+                No,
+                Yes,
+                DontCare
+            };
+
+            BinaryCriterion is_shadow_caster{BinaryCriterion::DontCare};
+            uint32_t layer{0xFFFFFFFF};
         };
 
         enum class SortingCriterion {
@@ -32,7 +39,7 @@ namespace Engine {
         RendererManager(RenderSystem & system);
         ~RendererManager();
 
-        void RegisterRendererComponent(MeshComponent & component);
+        RendererHandle RegisterRendererComponent(std::shared_ptr <MeshComponent> component);
 
         /**
          * @brief Unregister a component from the manager.
@@ -66,7 +73,15 @@ namespace Engine {
          * Actual uploading is performed by `FrameManager`.
          */
         RendererList FilterAndSortRenderers(FilterCriteria fc, SortingCriterion sc = SortingCriterion::None);
+
+        /**
+         * @brief Get the renderer data used for draw calls.
+         */
+        MeshComponent * GetRendererData (RendererHandle handle) const noexcept;
     };
+
+    using RendererHandle = RendererManager::RendererHandle;
+    using RendererList = RendererManager::RendererList;
 }
 
 #endif // RENDER_RENDERSYSTEM_RENDERERMANAGER

--- a/engine/Render/RenderSystem/RendererManager.h
+++ b/engine/Render/RenderSystem/RendererManager.h
@@ -8,80 +8,81 @@ namespace Engine {
     class RenderSystem;
 
     class MeshComponent;
+    namespace RenderSystemState {
+        class RendererManager {
+            RenderSystem & m_system;
+            struct impl;
+            std::unique_ptr <impl> pimpl;
+        public:
 
-    class RendererManager {
-        RenderSystem & m_system;
-        struct impl;
-        std::unique_ptr <impl> pimpl;
-    public:
+            struct FilterCriteria {
+                enum class BinaryCriterion : uint8_t {
+                    No,
+                    Yes,
+                    DontCare
+                };
 
-        struct FilterCriteria {
-            enum class BinaryCriterion : uint8_t {
-                No,
-                Yes,
-                DontCare
+                BinaryCriterion is_shadow_caster{BinaryCriterion::DontCare};
+                uint32_t layer{0xFFFFFFFF};
             };
 
-            BinaryCriterion is_shadow_caster{BinaryCriterion::DontCare};
-            uint32_t layer{0xFFFFFFFF};
+            enum class SortingCriterion {
+                None,
+                ByPriority,
+                ByMaterial,
+                ByDistanceToActiveCamera
+            };
+
+            using RendererHandle = uint32_t;
+            using RendererList = std::vector <RendererHandle>;
+
+            RendererManager(RenderSystem & system);
+            ~RendererManager();
+
+            RendererHandle RegisterRendererComponent(std::shared_ptr <MeshComponent> component);
+
+            /**
+             * @brief Unregister a component from the manager.
+             * It will no longer be present in the `RendererList` returned by the manager.
+             * Its underlying resources are not deallocated until a `UpdateRendererStates()` call,
+             * and its auxillary data will remain in the manager until a 
+             * `ClearUnregisteredRendererComponent()` call.
+             */
+            void UnregisterRendererComponent(RendererHandle handle);
+
+            /**
+             * @brief Update renderer component states.
+             * Eagerly loaded renderers which are not currently loaded will be prepared 
+             * to be submitted to GPU, and unregistered renderers are removed from GPU.
+             * 
+             * Actual uploading is performed by `FrameManager`.
+             */
+            void UpdateRendererStates();
+
+            /**
+             * @brief Clear up unregistered renderers from internal data structure, and
+             * cosolidate internal memory to avoid fragmentation.
+             */
+            void ClearUnregisteredRendererComponent();
+
+            /**
+             * @brief Filter and sort renderers based on given criteria.
+             * All returned renderers that are not loaded to GPU (i.e. lazily loaded) will 
+             * be prepared to be submitted.
+             * 
+             * Actual uploading is performed by `FrameManager`.
+             */
+            RendererList FilterAndSortRenderers(FilterCriteria fc, SortingCriterion sc = SortingCriterion::None);
+
+            /**
+             * @brief Get the renderer data used for draw calls.
+             */
+            MeshComponent * GetRendererData (RendererHandle handle) const noexcept;
         };
+    }
 
-        enum class SortingCriterion {
-            None,
-            ByPriority,
-            ByMaterial,
-            ByDistanceToActiveCamera
-        };
-
-        using RendererHandle = uint32_t;
-        using RendererList = std::vector <RendererHandle>;
-
-        RendererManager(RenderSystem & system);
-        ~RendererManager();
-
-        RendererHandle RegisterRendererComponent(std::shared_ptr <MeshComponent> component);
-
-        /**
-         * @brief Unregister a component from the manager.
-         * It will no longer be present in the `RendererList` returned by the manager.
-         * Its underlying resources are not deallocated until a `UpdateRendererStates()` call,
-         * and its auxillary data will remain in the manager until a 
-         * `ClearUnregisteredRendererComponent()` call.
-         */
-        void UnregisterRendererComponent(RendererHandle handle);
-
-        /**
-         * @brief Update renderer component states.
-         * Eagerly loaded renderers which are not currently loaded will be prepared 
-         * to be submitted to GPU, and unregistered renderers are removed from GPU.
-         * 
-         * Actual uploading is performed by `FrameManager`.
-         */
-        void UpdateRendererStates();
-
-        /**
-         * @brief Clear up unregistered renderers from internal data structure, and
-         * cosolidate internal memory to avoid fragmentation.
-         */
-        void ClearUnregisteredRendererComponent();
-
-        /**
-         * @brief Filter and sort renderers based on given criteria.
-         * All returned renderers that are not loaded to GPU (i.e. lazily loaded) will 
-         * be prepared to be submitted.
-         * 
-         * Actual uploading is performed by `FrameManager`.
-         */
-        RendererList FilterAndSortRenderers(FilterCriteria fc, SortingCriterion sc = SortingCriterion::None);
-
-        /**
-         * @brief Get the renderer data used for draw calls.
-         */
-        MeshComponent * GetRendererData (RendererHandle handle) const noexcept;
-    };
-
-    using RendererHandle = RendererManager::RendererHandle;
-    using RendererList = RendererManager::RendererList;
+    using RendererHandle = RenderSystemState::RendererManager::RendererHandle;
+    using RendererList = RenderSystemState::RendererManager::RendererList;
 }
 
 #endif // RENDER_RENDERSYSTEM_RENDERERMANAGER

--- a/engine/Render/RenderSystem/RendererManager.h
+++ b/engine/Render/RenderSystem/RendererManager.h
@@ -1,0 +1,72 @@
+#ifndef RENDER_RENDERSYSTEM_RENDERERMANAGER
+#define RENDER_RENDERSYSTEM_RENDERERMANAGER
+
+#include <memory>
+#include <vector>
+
+namespace Engine {
+    class RenderSystem;
+
+    class MeshComponent;
+
+    class RendererManager {
+        RenderSystem & m_system;
+        struct impl;
+        std::unique_ptr <impl> pimpl;
+    public:
+
+        struct FilterCriteria {
+            uint32_t layer;
+        };
+
+        enum class SortingCriterion {
+            None,
+            ByPriority,
+            ByMaterial,
+            ByDistanceToActiveCamera
+        };
+
+        using RendererHandle = uint32_t;
+        using RendererList = std::vector <RendererHandle>;
+
+        RendererManager(RenderSystem & system);
+        ~RendererManager();
+
+        void RegisterRendererComponent(MeshComponent & component);
+
+        /**
+         * @brief Unregister a component from the manager.
+         * It will no longer be present in the `RendererList` returned by the manager.
+         * Its underlying resources are not deallocated until a `UpdateRendererStates()` call,
+         * and its auxillary data will remain in the manager until a 
+         * `ClearUnregisteredRendererComponent()` call.
+         */
+        void UnregisterRendererComponent(RendererHandle handle);
+
+        /**
+         * @brief Update renderer component states.
+         * Eagerly loaded renderers which are not currently loaded will be prepared 
+         * to be submitted to GPU, and unregistered renderers are removed from GPU.
+         * 
+         * Actual uploading is performed by `SubmissionHelper` on `StartFrame()` call.
+         */
+        void UpdateRendererStates();
+
+        /**
+         * @brief Clear up unregistered renderers from internal data structure, and
+         * cosolidate internal memory to avoid fragmentation.
+         */
+        void ClearUnregisteredRendererComponent();
+
+        /**
+         * @brief Filter and sort renderers based on given criteria.
+         * All returned renderers that are not loaded to GPU (i.e. lazily loaded) will 
+         * be prepared to be submitted.
+         * 
+         * Actual uploading is performed by `SubmissionHelper` on `StartFrame()` call.
+         */
+        RendererList FilterAndSortRenderers(FilterCriteria fc, SortingCriterion sc = SortingCriterion::None);
+    };
+}
+
+#endif // RENDER_RENDERSYSTEM_RENDERERMANAGER

--- a/engine/Render/RenderSystem/RendererManager.h
+++ b/engine/Render/RenderSystem/RendererManager.h
@@ -48,7 +48,7 @@ namespace Engine {
          * Eagerly loaded renderers which are not currently loaded will be prepared 
          * to be submitted to GPU, and unregistered renderers are removed from GPU.
          * 
-         * Actual uploading is performed by `SubmissionHelper` on `StartFrame()` call.
+         * Actual uploading is performed by `FrameManager`.
          */
         void UpdateRendererStates();
 
@@ -63,7 +63,7 @@ namespace Engine {
          * All returned renderers that are not loaded to GPU (i.e. lazily loaded) will 
          * be prepared to be submitted.
          * 
-         * Actual uploading is performed by `SubmissionHelper` on `StartFrame()` call.
+         * Actual uploading is performed by `FrameManager`.
          */
         RendererList FilterAndSortRenderers(FilterCriteria fc, SortingCriterion sc = SortingCriterion::None);
     };

--- a/engine/Render/RenderSystem/RendererManager.h
+++ b/engine/Render/RenderSystem/RendererManager.h
@@ -6,8 +6,8 @@
 
 namespace Engine {
     class RenderSystem;
+    class RendererComponent;
 
-    class MeshComponent;
     namespace RenderSystemState {
         class RendererManager {
             RenderSystem & m_system;
@@ -39,7 +39,7 @@ namespace Engine {
             RendererManager(RenderSystem & system);
             ~RendererManager();
 
-            RendererHandle RegisterRendererComponent(std::shared_ptr <MeshComponent> component);
+            RendererHandle RegisterRendererComponent(std::shared_ptr <RendererComponent> component);
 
             /**
              * @brief Unregister a component from the manager.
@@ -77,7 +77,7 @@ namespace Engine {
             /**
              * @brief Get the renderer data used for draw calls.
              */
-            MeshComponent * GetRendererData (RendererHandle handle) const noexcept;
+            const RendererComponent * GetRendererData (RendererHandle handle) const noexcept;
         };
     }
 

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -107,7 +107,7 @@ namespace Engine::RenderSystemState {
         m_pending_operations.push(enqueued);
     }
 
-    void SubmissionHelper::StartFrame() {
+    void SubmissionHelper::ExecuteSubmission() {
         if (m_pending_operations.empty()) return;
 
         // Allocate one-time command buffer

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -1,6 +1,7 @@
 #include "SubmissionHelper.h"
 
 #include "Render/Memory/Texture.h"
+#include "Render/Memory/Buffer.h"
 #include "Render/Pipeline/CommandBuffer/BufferTransferHelper.h"
 #include "Render/Pipeline/CommandBuffer/LayoutTransferHelper.h"
 #include "Render/Renderer/HomogeneousMesh.h"
@@ -10,11 +11,21 @@
 #include <SDL3/SDL.h>
 
 namespace Engine::RenderSystemState {
-    SubmissionHelper::SubmissionHelper(RenderSystem &system) : m_system(system) {
+    struct SubmissionHelper::impl {
+        std::queue <CmdOperation> m_pending_operations {};
+        std::vector <Buffer> m_pending_dellocations {};
+
+        vk::UniqueCommandBuffer m_one_time_cb {};
+        vk::UniqueFence m_completion_fence {};
+    };
+
+    SubmissionHelper::SubmissionHelper(RenderSystem &system) : m_system(system), pimpl(std::make_unique<impl>()) {
         // Pre-allocate a fence
         vk::FenceCreateInfo fcinfo{};
-        m_completion_fence = system.getDevice().createFenceUnique(fcinfo);
+        pimpl->m_completion_fence = system.getDevice().createFenceUnique(fcinfo);
     }
+
+    SubmissionHelper::~SubmissionHelper() = default;
 
     void SubmissionHelper::EnqueueVertexBufferSubmission(const HomogeneousMesh &mesh) {
         auto enqueued = [&mesh, this](vk::CommandBuffer cb) {
@@ -29,9 +40,9 @@ namespace Engine::RenderSystemState {
 
             barriers[0] = BufferTransferHelper::GetBufferBarrier(BufferTransferHelper::BufferTransferType::VertexAfter);
             cb.pipelineBarrier2(vk::DependencyInfo{{}, barriers, {}, {}});
-            m_pending_dellocations.push_back(std::move(buffer));
+            pimpl->m_pending_dellocations.push_back(std::move(buffer));
         };
-        m_pending_operations.push(enqueued);
+        pimpl->m_pending_operations.push(enqueued);
     }
 
     void SubmissionHelper::EnqueueTextureBufferSubmission(
@@ -74,9 +85,9 @@ namespace Engine::RenderSystemState {
             dinfo.setImageMemoryBarriers(barriers);
             cb.pipelineBarrier2(dinfo);
 
-            m_pending_dellocations.push_back(std::move(buffer));
+            pimpl->m_pending_dellocations.push_back(std::move(buffer));
         };
-        m_pending_operations.push(enqueued);
+        pimpl->m_pending_operations.push(enqueued);
     }
 
     void SubmissionHelper::EnqueueTextureClear(const Texture &texture, std::tuple<float, float, float, float> color) {
@@ -104,11 +115,11 @@ namespace Engine::RenderSystemState {
             dinfo.setImageMemoryBarriers(barriers);
             cb.pipelineBarrier2(dinfo);
         };
-        m_pending_operations.push(enqueued);
+        pimpl->m_pending_operations.push(enqueued);
     }
 
     void SubmissionHelper::ExecuteSubmission() {
-        if (m_pending_operations.empty()) return;
+        if (pimpl->m_pending_operations.empty()) return;
 
         // Allocate one-time command buffer
         vk::CommandBufferAllocateInfo cbainfo{
@@ -116,40 +127,40 @@ namespace Engine::RenderSystemState {
         };
         auto cbs = m_system.getDevice().allocateCommandBuffersUnique(cbainfo);
         assert(cbs.size() == 1);
-        m_one_time_cb = std::move(cbs[0]);
-        DEBUG_SET_NAME_TEMPLATE(m_system.getDevice(), m_one_time_cb.get(), "One-time submission CB");
+        pimpl->m_one_time_cb = std::move(cbs[0]);
+        DEBUG_SET_NAME_TEMPLATE(m_system.getDevice(), pimpl->m_one_time_cb.get(), "One-time submission CB");
 
         // Record all operations
         vk::CommandBufferBeginInfo cbbinfo{vk::CommandBufferUsageFlagBits::eOneTimeSubmit};
-        m_one_time_cb->begin(cbbinfo);
-        DEBUG_CMD_START_LABEL(m_one_time_cb.get(), "Resource Submission");
+        pimpl->m_one_time_cb->begin(cbbinfo);
+        DEBUG_CMD_START_LABEL(pimpl->m_one_time_cb.get(), "Resource Submission");
 
-        while (!m_pending_operations.empty()) {
-            auto enqueued = m_pending_operations.front();
-            enqueued(m_one_time_cb.get());
-            m_pending_operations.pop();
+        while (!pimpl->m_pending_operations.empty()) {
+            auto enqueued = pimpl->m_pending_operations.front();
+            enqueued(pimpl->m_one_time_cb.get());
+            pimpl->m_pending_operations.pop();
         }
 
-        DEBUG_CMD_END_LABEL(m_one_time_cb.get());
-        m_one_time_cb->end();
+        DEBUG_CMD_END_LABEL(pimpl->m_one_time_cb.get());
+        pimpl->m_one_time_cb->end();
 
-        std::array<vk::CommandBuffer, 1> submitted_cb = {m_one_time_cb.get()};
+        std::array<vk::CommandBuffer, 1> submitted_cb = {pimpl->m_one_time_cb.get()};
         std::array<vk::SubmitInfo, 1> sinfos = {vk::SubmitInfo{{}, {}, submitted_cb, {}}};
-        m_system.getQueueInfo().graphicsQueue.submit(sinfos, {m_completion_fence.get()});
+        m_system.getQueueInfo().graphicsQueue.submit(sinfos, {pimpl->m_completion_fence.get()});
     }
 
     void SubmissionHelper::CompleteFrame() {
-        if (!m_one_time_cb) return;
+        if (!pimpl->m_one_time_cb) return;
 
         auto wfresult =
-            m_system.getDevice().waitForFences({m_completion_fence.get()}, true, std::numeric_limits<uint64_t>::max());
+            m_system.getDevice().waitForFences({pimpl->m_completion_fence.get()}, true, std::numeric_limits<uint64_t>::max());
         if (wfresult != vk::Result::eSuccess) {
             SDL_LogError(SDL_LOG_CATEGORY_RENDER, "An error occured when waiting for submission fence.");
         }
 
-        m_system.getDevice().resetFences({m_completion_fence.get()});
-        m_one_time_cb.reset();
-        m_pending_dellocations.clear();
+        m_system.getDevice().resetFences({pimpl->m_completion_fence.get()});
+        pimpl->m_one_time_cb.reset();
+        pimpl->m_pending_dellocations.clear();
     }
 
 } // namespace Engine::RenderSystemState

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -1,7 +1,7 @@
 #include "SubmissionHelper.h"
 
-#include "Render/Memory/Texture.h"
 #include "Render/Memory/Buffer.h"
+#include "Render/Memory/Texture.h"
 #include "Render/Pipeline/CommandBuffer/BufferTransferHelper.h"
 #include "Render/Pipeline/CommandBuffer/LayoutTransferHelper.h"
 #include "Render/Renderer/HomogeneousMesh.h"
@@ -12,11 +12,11 @@
 
 namespace Engine::RenderSystemState {
     struct SubmissionHelper::impl {
-        std::queue <CmdOperation> m_pending_operations {};
-        std::vector <Buffer> m_pending_dellocations {};
+        std::queue<CmdOperation> m_pending_operations{};
+        std::vector<Buffer> m_pending_dellocations{};
 
-        vk::UniqueCommandBuffer m_one_time_cb {};
-        vk::UniqueFence m_completion_fence {};
+        vk::UniqueCommandBuffer m_one_time_cb{};
+        vk::UniqueFence m_completion_fence{};
     };
 
     SubmissionHelper::SubmissionHelper(RenderSystem &system) : m_system(system), pimpl(std::make_unique<impl>()) {
@@ -152,8 +152,9 @@ namespace Engine::RenderSystemState {
     void SubmissionHelper::CompleteFrame() {
         if (!pimpl->m_one_time_cb) return;
 
-        auto wfresult =
-            m_system.getDevice().waitForFences({pimpl->m_completion_fence.get()}, true, std::numeric_limits<uint64_t>::max());
+        auto wfresult = m_system.getDevice().waitForFences(
+            {pimpl->m_completion_fence.get()}, true, std::numeric_limits<uint64_t>::max()
+        );
         if (wfresult != vk::Result::eSuccess) {
             SDL_LogError(SDL_LOG_CATEGORY_RENDER, "An error occured when waiting for submission fence.");
         }

--- a/engine/Render/RenderSystem/SubmissionHelper.h
+++ b/engine/Render/RenderSystem/SubmissionHelper.h
@@ -7,9 +7,8 @@
 #include <vulkan/vulkan.hpp>
 
 namespace Engine {
-    class Buffer;
-    class HomogeneousMesh;
     class Texture;
+    class HomogeneousMesh;
 
     namespace RenderSystemState {
         /// @brief A helper for submitting data to GPU.
@@ -19,13 +18,11 @@ namespace Engine {
         private:
             RenderSystem & m_system;
 
-            std::queue <CmdOperation> m_pending_operations {};
-            std::vector <Buffer> m_pending_dellocations {};
-
-            vk::UniqueCommandBuffer m_one_time_cb {};
-            vk::UniqueFence m_completion_fence {};
+            struct impl;
+            std::unique_ptr <impl> pimpl;
         public:
             SubmissionHelper (RenderSystem & system);
+            ~SubmissionHelper();
 
             /***
              * @brief Enqueue a vertex buffer uploading.

--- a/engine/Render/RenderSystem/SubmissionHelper.h
+++ b/engine/Render/RenderSystem/SubmissionHelper.h
@@ -63,10 +63,11 @@ namespace Engine {
             void EnqueueTextureClear(const Texture & texture, std::tuple<float, float, float, float> color_rgba);
 
             /***
-             * @brief Start the frame. Allocated a new command buffer if needed, record all pending operations, and submit the
+             * @brief Execute staged submissions. 
+             * Allocated a new command buffer if needed, record all pending operations, and submit the
              * buffer to the graphics queue allocated by the render system.
              */
-            void StartFrame();
+            void ExecuteSubmission();
 
             /***
              * @brief Complete the frame. Wait for execution of the disposable command buffer, de-allocate staging buffers,

--- a/engine/Render/Renderer/HomogeneousMesh.cpp
+++ b/engine/Render/Renderer/HomogeneousMesh.cpp
@@ -7,18 +7,18 @@
 namespace Engine {
 
     struct HomogeneousMesh::impl {
-        std::unique_ptr <Buffer> m_buffer {};
-        std::vector <vk::DeviceSize> m_buffer_offsets {};
+        std::unique_ptr<Buffer> m_buffer{};
+        std::vector<vk::DeviceSize> m_buffer_offsets{};
 
-        bool m_updated {false};
+        bool m_updated{false};
 
-        uint64_t m_total_allocated_buffer_size {0};
+        uint64_t m_total_allocated_buffer_size{0};
 
-        std::shared_ptr<AssetRef> m_mesh_asset {};
-        size_t m_submesh_idx {};
-        MeshVertexType m_type {};
+        std::shared_ptr<AssetRef> m_mesh_asset{};
+        size_t m_submesh_idx{};
+        MeshVertexType m_type{};
 
-        void WriteToMemory(std::byte * pointer) const;
+        void WriteToMemory(std::byte *pointer) const;
         /**
          * @brief Allocate buffer and update pre-calculated offsets.
          * Called before `CreateStagingBuffer()`.
@@ -70,21 +70,33 @@ namespace Engine {
             // Generate buffer offsets
             m_buffer_offsets.clear();
             m_buffer_offsets.push_back(0);
-            switch(m_type) {
+            switch (m_type) {
             case MeshVertexType::Skinned:
                 m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexPosition));
-                m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *m_buffer_offsets.rbegin());
-                m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeExtended) + *m_buffer_offsets.rbegin());
-                m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeSkinned) + *m_buffer_offsets.rbegin());
+                m_buffer_offsets.push_back(
+                    new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *m_buffer_offsets.rbegin()
+                );
+                m_buffer_offsets.push_back(
+                    new_vertex_count * sizeof(VertexStruct::VertexAttributeExtended) + *m_buffer_offsets.rbegin()
+                );
+                m_buffer_offsets.push_back(
+                    new_vertex_count * sizeof(VertexStruct::VertexAttributeSkinned) + *m_buffer_offsets.rbegin()
+                );
                 break;
             case MeshVertexType::Extended:
                 m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexPosition));
-                m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *m_buffer_offsets.rbegin());
-                m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeExtended) + *m_buffer_offsets.rbegin());
+                m_buffer_offsets.push_back(
+                    new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *m_buffer_offsets.rbegin()
+                );
+                m_buffer_offsets.push_back(
+                    new_vertex_count * sizeof(VertexStruct::VertexAttributeExtended) + *m_buffer_offsets.rbegin()
+                );
                 break;
             case MeshVertexType::Basic:
                 m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexPosition));
-                m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *m_buffer_offsets.rbegin());
+                m_buffer_offsets.push_back(
+                    new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *m_buffer_offsets.rbegin()
+                );
             }
 
             assert(*m_buffer_offsets.rbegin() == buffer_size - new_vertex_index_count * sizeof(uint32_t));
@@ -117,20 +129,19 @@ namespace Engine {
         std::memcpy(&pointer[offset], positions.data(), positions.size() * sizeof(VertexStruct::VertexPosition));
         offset += positions.size() * sizeof(VertexStruct::VertexPosition);
         // Attributes
-        std::memcpy(&pointer[offset], attributes.data(), attributes.size() * sizeof(VertexStruct::VertexAttributeBasic));
+        std::memcpy(
+            &pointer[offset], attributes.data(), attributes.size() * sizeof(VertexStruct::VertexAttributeBasic)
+        );
         offset += attributes.size() * sizeof(VertexStruct::VertexAttributeBasic);
         // Index
         std::memcpy(&pointer[offset], indices.data(), indices.size() * sizeof(uint32_t));
         offset += indices.size() * sizeof(uint32_t);
-
     }
 
     vk::PipelineVertexInputStateCreateInfo HomogeneousMesh::GetVertexInputState(MeshVertexType type) {
         assert(type == MeshVertexType::Basic && "Unimplemented");
         return vk::PipelineVertexInputStateCreateInfo{
-            vk::PipelineVertexInputStateCreateFlags{0}, 
-            VertexStruct::BINDINGS_BASIC,
-            VertexStruct::ATTRIBUTES_BASIC
+            vk::PipelineVertexInputStateCreateFlags{0}, VertexStruct::BINDINGS_BASIC, VertexStruct::ATTRIBUTES_BASIC
         };
     }
 
@@ -158,18 +169,18 @@ namespace Engine {
     uint64_t HomogeneousMesh::impl::GetExpectedBufferSize() const {
         auto vertex_cnt = GetVertexCount();
         uint64_t size = GetVertexIndexCount() * sizeof(uint32_t);
-        switch(m_type) {
-            case MeshVertexType::Skinned:
-                size += vertex_cnt * sizeof(VertexStruct::VertexAttributeSkinned);
-                [[fallthrough]];
-            case MeshVertexType::Extended:
-                size += vertex_cnt * sizeof(VertexStruct::VertexAttributeExtended);
-                [[fallthrough]];
-            case MeshVertexType::Basic:
-                size += vertex_cnt * sizeof(VertexStruct::VertexAttributeBasic);
-                [[fallthrough]];
-            case MeshVertexType::Position:
-                size += vertex_cnt * sizeof(VertexStruct::VertexPosition);
+        switch (m_type) {
+        case MeshVertexType::Skinned:
+            size += vertex_cnt * sizeof(VertexStruct::VertexAttributeSkinned);
+            [[fallthrough]];
+        case MeshVertexType::Extended:
+            size += vertex_cnt * sizeof(VertexStruct::VertexAttributeExtended);
+            [[fallthrough]];
+        case MeshVertexType::Basic:
+            size += vertex_cnt * sizeof(VertexStruct::VertexAttributeBasic);
+            [[fallthrough]];
+        case MeshVertexType::Position:
+            size += vertex_cnt * sizeof(VertexStruct::VertexPosition);
         }
         return size;
     }
@@ -181,8 +192,7 @@ namespace Engine {
         return *pimpl->m_buffer;
     }
 
-    std::pair<vk::Buffer, std::vector<vk::DeviceSize>>
-    HomogeneousMesh::GetVertexBufferInfo() const {
+    std::pair<vk::Buffer, std::vector<vk::DeviceSize>> HomogeneousMesh::GetVertexBufferInfo() const {
         assert(pimpl->m_buffer->GetBuffer());
         return std::make_pair(pimpl->m_buffer->GetBuffer(), pimpl->m_buffer_offsets);
     }

--- a/engine/Render/Renderer/HomogeneousMesh.cpp
+++ b/engine/Render/Renderer/HomogeneousMesh.cpp
@@ -5,34 +5,85 @@
 #include <vulkan/vulkan.hpp>
 
 namespace Engine {
+
+    struct HomogeneousMesh::impl {
+        std::unique_ptr <Buffer> m_buffer;
+        std::vector <vk::DeviceSize> m_buffer_offsets;
+
+        bool m_updated {false};
+
+        uint64_t m_total_allocated_buffer_size {0};
+
+        std::shared_ptr<AssetRef> m_mesh_asset;
+        size_t m_submesh_idx;
+        MeshVertexType m_type;
+
+        void WriteToMemory(std::byte * pointer) const;
+    };
+
     HomogeneousMesh::HomogeneousMesh(
-        std::weak_ptr<RenderSystem> system, std::shared_ptr<AssetRef> mesh_asset, size_t submesh_idx
-    ) : m_system(system), m_buffer(system.lock()), m_mesh_asset(mesh_asset), m_submesh_idx(submesh_idx) {
+        std::weak_ptr<RenderSystem> system,
+        std::shared_ptr<AssetRef> mesh_asset,
+        size_t submesh_idx,
+        MeshVertexType type
+    ) : m_system(system), pimpl(std::make_unique<impl>()) {
+        pimpl->m_mesh_asset = mesh_asset;
+        pimpl->m_submesh_idx = submesh_idx;
+
+        assert(type == MeshVertexType::Basic && "Unimplemented");
+        pimpl->m_type = type;
+        pimpl->m_buffer = std::make_unique<Buffer>(system.lock());
     }
 
     HomogeneousMesh::~HomogeneousMesh() {
     }
 
     void HomogeneousMesh::Prepare() {
-        const uint32_t new_vertex_count = GetVertexCount();
         const uint64_t buffer_size = GetExpectedBufferSize();
 
-        if (m_allocated_buffer_size != buffer_size) {
-            m_updated = true;
+        if (pimpl->m_total_allocated_buffer_size != buffer_size) {
+            pimpl->m_total_allocated_buffer_size = 0;
+            pimpl->m_updated = true;
+
+            const uint32_t new_vertex_count = GetVertexCount();
+            const uint32_t new_vertex_index_count = GetVertexIndexCount();
             SDL_LogVerbose(
                 SDL_LOG_CATEGORY_RENDER,
-                "(Re-)Allocating buffer and memory for %u vertices (%llu bytes).",
+                "(Re-)Allocating buffer and memory for %u vertices and %u indices (%llu bytes).",
                 new_vertex_count,
+                new_vertex_index_count,
                 buffer_size
             );
-            m_buffer.Create(Buffer::BufferType::Vertex, buffer_size, "Buffer - mesh vertices");
-            m_allocated_buffer_size = buffer_size;
+            pimpl->m_buffer->Create(Buffer::BufferType::Vertex, buffer_size, "Buffer - mesh vertices");
+            pimpl->m_total_allocated_buffer_size = buffer_size;
+
+            // Generate buffer offsets
+            pimpl->m_buffer_offsets.clear();
+            pimpl->m_buffer_offsets.push_back(0);
+            switch(pimpl->m_type) {
+            case MeshVertexType::Skinned:
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexPosition));
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *pimpl->m_buffer_offsets.rbegin());
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeExtended) + *pimpl->m_buffer_offsets.rbegin());
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeSkinned) + *pimpl->m_buffer_offsets.rbegin());
+                break;
+            case MeshVertexType::Extended:
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexPosition));
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *pimpl->m_buffer_offsets.rbegin());
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeExtended) + *pimpl->m_buffer_offsets.rbegin());
+                break;
+            case MeshVertexType::Basic:
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexPosition));
+                pimpl->m_buffer_offsets.push_back(new_vertex_count * sizeof(VertexStruct::VertexAttributeBasic) + *pimpl->m_buffer_offsets.rbegin());
+            }
+
+            assert(*pimpl->m_buffer_offsets.rbegin() == buffer_size - new_vertex_index_count * sizeof(uint32_t));
         }
     }
 
     bool HomogeneousMesh::NeedCommitment() {
-        bool need = m_updated;
-        m_updated = false;
+        bool need = pimpl->m_updated;
+        pimpl->m_updated = false;
         return need;
     }
 
@@ -43,66 +94,83 @@ namespace Engine {
         buffer.Create(Buffer::BufferType::Staging, buffer_size, "Buffer - mesh staging");
 
         std::byte *data = buffer.Map();
-        WriteToMemory(data);
+        pimpl->WriteToMemory(data);
         buffer.Flush();
         buffer.Unmap();
 
         return buffer;
     }
 
-    void HomogeneousMesh::WriteToMemory(std::byte *pointer) const {
+    void HomogeneousMesh::impl::WriteToMemory(std::byte *pointer) const {
         uint64_t offset = 0;
         auto &mesh_asset = *m_mesh_asset->as<MeshAsset>();
         const auto &positions = mesh_asset.m_submeshes[m_submesh_idx].m_positions;
-        const auto &attributes = mesh_asset.m_submeshes[m_submesh_idx].m_attributes;
+        const auto &attributes = mesh_asset.m_submeshes[m_submesh_idx].m_attributes_basic;
         const auto &indices = mesh_asset.m_submeshes[m_submesh_idx].m_indices;
         // Position
-        std::memcpy(&pointer[offset], positions.data(), positions.size() * VertexStruct::VERTEX_POSITION_SIZE);
-        offset += positions.size() * VertexStruct::VERTEX_POSITION_SIZE;
+        std::memcpy(&pointer[offset], positions.data(), positions.size() * sizeof(VertexStruct::VertexPosition));
+        offset += positions.size() * sizeof(VertexStruct::VertexPosition);
         // Attributes
-        std::memcpy(&pointer[offset], attributes.data(), attributes.size() * VertexStruct::VERTEX_ATTRIBUTE_SIZE);
-        offset += attributes.size() * VertexStruct::VERTEX_ATTRIBUTE_SIZE;
+        std::memcpy(&pointer[offset], attributes.data(), attributes.size() * sizeof(VertexStruct::VertexAttributeBasic));
+        offset += attributes.size() * sizeof(VertexStruct::VertexAttributeBasic);
         // Index
         std::memcpy(&pointer[offset], indices.data(), indices.size() * sizeof(uint32_t));
         offset += indices.size() * sizeof(uint32_t);
-        assert(offset == GetExpectedBufferSize());
+
     }
 
-    vk::PipelineVertexInputStateCreateInfo HomogeneousMesh::GetVertexInputState() {
-        return vk::PipelineVertexInputStateCreateInfo{vk::PipelineVertexInputStateCreateFlags{0}, bindings, attributes};
+    vk::PipelineVertexInputStateCreateInfo HomogeneousMesh::GetVertexInputState(MeshVertexType type) {
+        assert(type == MeshVertexType::Basic && "Unimplemented");
+        return vk::PipelineVertexInputStateCreateInfo{
+            vk::PipelineVertexInputStateCreateFlags{0}, 
+            VertexStruct::BINDINGS_BASIC,
+            VertexStruct::ATTRIBUTES_BASIC
+        };
     }
 
-    std::pair<vk::Buffer, vk::DeviceSize> HomogeneousMesh::GetIndexInfo() const {
-        assert(this->m_buffer.GetBuffer());
-        uint64_t total_size = GetVertexCount() * VertexStruct::VERTEX_TOTAL_SIZE;
-        return std::make_pair(m_buffer.GetBuffer(), total_size);
+    std::pair<vk::Buffer, vk::DeviceSize> HomogeneousMesh::GetIndexBufferInfo() const {
+        assert(pimpl->m_buffer->GetBuffer());
+        // Last offset is the offset of index buffer.
+        return std::make_pair(pimpl->m_buffer->GetBuffer(), *(pimpl->m_buffer_offsets.rbegin()));
     }
 
     uint32_t HomogeneousMesh::GetVertexIndexCount() const {
-        return m_mesh_asset->as<MeshAsset>()->GetSubmeshVertexIndexCount(m_submesh_idx);
+        return pimpl->m_mesh_asset->as<MeshAsset>()->GetSubmeshVertexIndexCount(pimpl->m_submesh_idx);
     }
 
     uint32_t HomogeneousMesh::GetVertexCount() const {
-        return m_mesh_asset->as<MeshAsset>()->GetSubmeshVertexCount(m_submesh_idx);
+        return pimpl->m_mesh_asset->as<MeshAsset>()->GetSubmeshVertexCount(pimpl->m_submesh_idx);
     }
 
     uint64_t HomogeneousMesh::GetExpectedBufferSize() const {
-        return m_mesh_asset->as<MeshAsset>()->GetSubmeshExpectedBufferSize(m_submesh_idx);
+        auto vertex_cnt = this->GetVertexCount();
+        uint64_t size = this->GetVertexIndexCount() * sizeof(uint32_t);
+        switch(pimpl->m_type) {
+            case MeshVertexType::Skinned:
+                size += vertex_cnt * sizeof(VertexStruct::VertexAttributeSkinned);
+
+            [[fallthrough]]
+            case MeshVertexType::Extended:
+                size += vertex_cnt * sizeof(VertexStruct::VertexAttributeExtended);
+
+            [[fallthrough]]
+            case MeshVertexType::Basic:
+                size += vertex_cnt * sizeof(VertexStruct::VertexAttributeBasic);
+            
+            [[fallthrough]]
+            case MeshVertexType::Position:
+                size += vertex_cnt * sizeof(VertexStruct::VertexPosition);
+        }
+        return size;
     }
 
     const Buffer &HomogeneousMesh::GetBuffer() const {
-        return m_buffer;
+        return *pimpl->m_buffer;
     }
 
-    std::pair<
-        std::array<vk::Buffer, HomogeneousMesh::BINDING_COUNT>,
-        std::array<vk::DeviceSize, HomogeneousMesh::BINDING_COUNT>>
-    HomogeneousMesh::GetBindingInfo() const {
-        assert(this->m_buffer.GetBuffer());
-        std::array<vk::Buffer, BINDING_COUNT> buffer{this->m_buffer.GetBuffer(), this->m_buffer.GetBuffer()};
-        std::array<vk::DeviceSize, BINDING_COUNT> binding_offset{
-            0, GetVertexCount() * VertexStruct::VERTEX_POSITION_SIZE
-        };
-        return std::make_pair(buffer, binding_offset);
+    std::pair<vk::Buffer, std::vector<vk::DeviceSize>>
+    HomogeneousMesh::GetVertexBufferInfo() const {
+        assert(pimpl->m_buffer->GetBuffer());
+        return std::make_pair(pimpl->m_buffer->GetBuffer(), pimpl->m_buffer_offsets);
     }
 } // namespace Engine

--- a/engine/Render/Renderer/HomogeneousMesh.h
+++ b/engine/Render/Renderer/HomogeneousMesh.h
@@ -10,6 +10,7 @@ namespace Engine{
     
     /// @brief A homogeneous mesh of only one material at runtime, constructed from mesh asset.
     class HomogeneousMesh {
+        std::weak_ptr <RenderSystem> m_system;
         struct impl;
         std::unique_ptr <impl> pimpl;
     public:
@@ -28,18 +29,33 @@ namespace Engine{
         );
         ~HomogeneousMesh();
 
-        void Prepare();
-
-        /// @brief Check if the vertex buffer of the mesh needs to be commited to GPU.
-        /// The flag is always set to `false` after this check.
-        /// @return whether commitment is needed.
-        bool NeedCommitment();
-
+        /**
+         * @brief Create a staging buffer containing all vertices data.
+         * 
+         * This method is automatically called on mesh submission, and you typically do
+         * not need to call it manually.
+         */
         Buffer CreateStagingBuffer() const;
+
+        /**
+         * @brief Get vertex index count viz. how many vertices are drawn in the draw call.
+         */
         uint32_t GetVertexIndexCount() const;
+
+        /**
+         * @brief Get vertex count viz. how many distinct vertices data are there.
+         */
         uint32_t GetVertexCount() const;
+
+        /**
+         * @brief Get expected buffer size. The buffer contains all vertex attributes
+         * and indices used for draw calls.
+         */
         uint64_t GetExpectedBufferSize() const;
 
+        /**
+         * @brief Get the underlying buffer, which contains all vertex data.
+         */
         const Buffer & GetBuffer() const;
 
         /**
@@ -50,6 +66,7 @@ namespace Engine{
          * POSITION ... | BASICATTR ... | EXTENDEDATTR ... | SKINNEDATTR ... | INDEX ...
          * ^ Offset 0   | ^ Offset 1    | ^ Offset 2       | ^ Offset 3      | ^ Offset 4
          * ```
+         * Note that index buffer have a different element count of the rest of buffers.
          */
         std::pair <vk::Buffer, std::vector<vk::DeviceSize>>
         GetVertexBufferInfo() const;
@@ -62,14 +79,15 @@ namespace Engine{
          * POSITION ... | BASICATTR ... | EXTENDEDATTR ... | SKINNEDATTR ... | INDEX ...
          * ^ Offset 0   | ^ Offset 1    | ^ Offset 2       | ^ Offset 3      | ^ Offset 4
          * ```
+         * Note that index buffer have a different element count of the rest of buffers.
          */
         std::pair <vk::Buffer, vk::DeviceSize>
         GetIndexBufferInfo() const;
 
+        /**
+         * @brief Query `VkPipelineVertexInputStateCreateInfo` associated with the mesh type.
+         */
         static vk::PipelineVertexInputStateCreateInfo GetVertexInputState(MeshVertexType type = MeshVertexType::Basic);
-
-    protected:
-        std::weak_ptr <RenderSystem> m_system;
     };
 };
 

--- a/engine/Render/Renderer/HomogeneousMesh.h
+++ b/engine/Render/Renderer/HomogeneousMesh.h
@@ -10,11 +10,22 @@ namespace Engine{
     
     /// @brief A homogeneous mesh of only one material at runtime, constructed from mesh asset.
     class HomogeneousMesh {
+        struct impl;
+        std::unique_ptr <impl> pimpl;
     public:
+        enum class MeshVertexType {
+            Position,
+            Basic,
+            Extended,
+            Skinned
+        };
 
-        static constexpr const uint32_t BINDING_COUNT = 2;
-
-        HomogeneousMesh(std::weak_ptr <RenderSystem> system, std::shared_ptr<AssetRef> mesh_asset, size_t submesh_idx);
+        HomogeneousMesh(
+            std::weak_ptr <RenderSystem> system, 
+            std::shared_ptr<AssetRef> mesh_asset, 
+            size_t submesh_idx,
+            MeshVertexType type = MeshVertexType::Basic
+        );
         ~HomogeneousMesh();
 
         void Prepare();
@@ -28,65 +39,37 @@ namespace Engine{
         uint32_t GetVertexIndexCount() const;
         uint32_t GetVertexCount() const;
         uint64_t GetExpectedBufferSize() const;
+
         const Buffer & GetBuffer() const;
 
-        std::pair <
-            std::array<vk::Buffer, HomogeneousMesh::BINDING_COUNT>, 
-            std::array<vk::DeviceSize, HomogeneousMesh::BINDING_COUNT>
-        >
-        GetBindingInfo() const;
+        /**
+         * @brief Get vertex attribute buffers, along with their offsets in the buffer.
+         * 
+         * Our vertex attributes are allocated in the same buffer with different offsets:
+         * ```
+         * POSITION ... | BASICATTR ... | EXTENDEDATTR ... | SKINNEDATTR ... | INDEX ...
+         * ^ Offset 0   | ^ Offset 1    | ^ Offset 2       | ^ Offset 3      | ^ Offset 4
+         * ```
+         */
+        std::pair <vk::Buffer, std::vector<vk::DeviceSize>>
+        GetVertexBufferInfo() const;
 
+        /**
+         * @brief Get vertex index buffer, along with its offset in the buffer.
+         * 
+         * Our vertex attributes along with indices are allocated in the same buffer with different offsets:
+         * ```
+         * POSITION ... | BASICATTR ... | EXTENDEDATTR ... | SKINNEDATTR ... | INDEX ...
+         * ^ Offset 0   | ^ Offset 1    | ^ Offset 2       | ^ Offset 3      | ^ Offset 4
+         * ```
+         */
         std::pair <vk::Buffer, vk::DeviceSize>
-        GetIndexInfo() const;
+        GetIndexBufferInfo() const;
 
-        static vk::PipelineVertexInputStateCreateInfo GetVertexInputState();
+        static vk::PipelineVertexInputStateCreateInfo GetVertexInputState(MeshVertexType type = MeshVertexType::Basic);
 
     protected:
         std::weak_ptr <RenderSystem> m_system;
-
-        static constexpr const std::array<vk::VertexInputBindingDescription, BINDING_COUNT> bindings = {
-            // Position
-            vk::VertexInputBindingDescription{0, VertexStruct::VERTEX_POSITION_SIZE, vk::VertexInputRate::eVertex},
-            // Other attributes
-            vk::VertexInputBindingDescription{1, VertexStruct::VERTEX_ATTRIBUTE_SIZE, vk::VertexInputRate::eVertex}
-        };
-
-        static constexpr const std::array<vk::VertexInputAttributeDescription, VertexStruct::VERTEX_ATTRIBUTE_COUNT + 1> attributes = {
-            // Position
-            vk::VertexInputAttributeDescription{0, bindings[0].binding, vk::Format::eR32G32B32Sfloat, 0},
-            // Vertex color
-            vk::VertexInputAttributeDescription{
-                1, 
-                bindings[1].binding, 
-                vk::Format::eR32G32B32Sfloat, 
-                VertexStruct::OFFSET_COLOR
-            },
-            // Vertex normal
-            vk::VertexInputAttributeDescription{
-                2, 
-                bindings[1].binding, 
-                vk::Format::eR32G32B32Sfloat, 
-                VertexStruct::OFFSET_NORMAL
-            },
-            // Texcoord 1
-            vk::VertexInputAttributeDescription{
-                3,
-                bindings[1].binding,
-                vk::Format::eR32G32Sfloat,
-                VertexStruct::OFFSET_TEXCOORD1
-            }
-        };
-
-        Buffer m_buffer;
-
-        bool m_updated {false};
-
-        uint64_t m_allocated_buffer_size {0};
-
-        std::shared_ptr<AssetRef> m_mesh_asset;
-        size_t m_submesh_idx;
-
-        void WriteToMemory(std::byte * pointer) const;
     };
 };
 

--- a/engine/Render/Renderer/VertexStruct.h
+++ b/engine/Render/Renderer/VertexStruct.h
@@ -2,27 +2,96 @@
 #define RENDER_RENDERER_VERTEXSTRUCT_INCLUDED
 
 #include <cctype>
+#include <vulkan/vulkan.hpp>
 
 namespace Engine {
     namespace VertexStruct {
         struct VertexPosition {
+            // Object space position vector.
             float position[3];
         };
 
-        struct VertexAttribute {
+        struct VertexAttributeBasic {
+            // Vertex color in linear space.
             float color[3];
+            // Object space normal vector.
             float normal[3];
+            // Texture coordinate (UV) No. 1
             float texcoord1[2];
         };
 
-        constexpr uint32_t OFFSET_COLOR = offsetof(VertexAttribute, color);
-        constexpr uint32_t OFFSET_NORMAL = offsetof(VertexAttribute, normal);
-        constexpr uint32_t OFFSET_TEXCOORD1 = offsetof(VertexAttribute, texcoord1);
+        struct VertexAttributeExtended {
+            // Object space tangent vector.
+            // W component is used to determine bi-tangent:
+            // `bitangent = cross(normal, tangent.xyz) * tangent.w;`
+            float tangent[4];
+            // Texture coordinate (UV) No. 2
+            float texcoord2[2];
+            // Texture coordinate (UV) No. 3
+            float texcoord3[2];
+            // Texture coordinate (UV) No. 4
+            float texcoord4[2];
+        };
 
-        constexpr uint32_t VERTEX_ATTRIBUTE_COUNT = 3;
-        constexpr size_t VERTEX_POSITION_SIZE = sizeof(VertexPosition);
-        constexpr size_t VERTEX_ATTRIBUTE_SIZE = sizeof(VertexAttribute);
-        constexpr size_t VERTEX_TOTAL_SIZE = VERTEX_POSITION_SIZE + VERTEX_ATTRIBUTE_SIZE;
+        struct VertexAttributeSkinned {
+            uint16_t bone_id[4];
+            float weight[4];
+        };
+
+        constexpr uint32_t OFFSET_COLOR = offsetof(VertexAttributeBasic, color);
+        constexpr uint32_t OFFSET_NORMAL = offsetof(VertexAttributeBasic, normal);
+        constexpr uint32_t OFFSET_TEXCOORD1 = offsetof(VertexAttributeBasic, texcoord1);
+
+        constexpr uint32_t VERTEX_ATTRIBUTE_BASIC_COUNT = 3;
+        constexpr uint32_t VERTEX_ATTRIBUTE_EXTENDED_COUNT = 4;
+        constexpr uint32_t VERTEX_ATTRIBUTE_SKINNED_COUNT = 2;
+
+        constexpr const std::array <size_t, 4> PER_VERTEX_SIZE_DELTA = {
+            sizeof (VertexPosition),
+            sizeof (VertexAttributeBasic),
+            sizeof (VertexAttributeExtended),
+            sizeof (VertexAttributeSkinned)
+        };
+
+        constexpr const std::array <size_t, 4> PER_VERTEX_SIZE = {
+            sizeof (VertexPosition),
+            sizeof (VertexPosition) + sizeof (VertexAttributeBasic),
+            sizeof (VertexPosition) + sizeof (VertexAttributeBasic) + sizeof (VertexAttributeExtended),
+            sizeof (VertexPosition) + sizeof (VertexAttributeBasic) + sizeof (VertexAttributeExtended) + sizeof (VertexAttributeSkinned)
+        };
+
+        constexpr const std::array<vk::VertexInputBindingDescription, 2> BINDINGS_BASIC = {
+            // Position
+            vk::VertexInputBindingDescription{0, sizeof(VertexPosition), vk::VertexInputRate::eVertex},
+            // Other attributes
+            vk::VertexInputBindingDescription{1, sizeof(VertexAttributeBasic), vk::VertexInputRate::eVertex}
+        };
+        constexpr const std::array<vk::VertexInputAttributeDescription, VertexStruct::VERTEX_ATTRIBUTE_BASIC_COUNT + 1> ATTRIBUTES_BASIC = {
+            // Position
+            vk::VertexInputAttributeDescription{0, BINDINGS_BASIC[0].binding, vk::Format::eR32G32B32Sfloat, 0},
+            // Vertex color
+            vk::VertexInputAttributeDescription{
+                1, 
+                BINDINGS_BASIC[1].binding, 
+                vk::Format::eR32G32B32Sfloat, 
+                VertexStruct::OFFSET_COLOR
+            },
+            // Vertex normal
+            vk::VertexInputAttributeDescription{
+                2, 
+                BINDINGS_BASIC[1].binding, 
+                vk::Format::eR32G32B32Sfloat, 
+                VertexStruct::OFFSET_NORMAL
+            },
+            // Texcoord 1
+            vk::VertexInputAttributeDescription{
+                3,
+                BINDINGS_BASIC[1].binding,
+                vk::Format::eR32G32Sfloat,
+                VertexStruct::OFFSET_TEXCOORD1
+            }
+        };
+
     };
 };
 

--- a/example/editor_example/main.cpp
+++ b/example/editor_example/main.cpp
@@ -147,7 +147,6 @@ int main() {
         rsys->GetFrameManager().CompositeToFramebufferAndPresent();
     }
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "Unloading Main-class");
 

--- a/example/editor_run_game_example/main.cpp
+++ b/example/editor_run_game_example/main.cpp
@@ -245,7 +245,6 @@ int main() {
         rsys->GetFrameManager().CompositeToFramebufferAndPresent();
     }
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "Unloading Main-class");
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,11 @@ target_link_libraries(camera_transform_test engine)
 add_test(NAME camera_transform_test COMMAND camera_transform_test)
 set_target_properties(camera_transform_test PROPERTIES FOLDER tests)
 
+add_executable(flag_bits_test flag_bits_test.cpp)
+target_link_libraries(flag_bits_test engine)
+add_test(NAME flag_bits_test COMMAND flag_bits_test)
+set_target_properties(flag_bits_test PROPERTIES FOLDER tests)
+
 add_executable(SDL_init_test SDL_init_test.cpp)
 target_link_libraries(SDL_init_test engine)
 add_test(NAME SDL_init_test COMMAND SDL_init_test)

--- a/test/complex_mesh_test.cpp
+++ b/test/complex_mesh_test.cpp
@@ -269,7 +269,7 @@ int main(int argc, char **argv) {
     // Setup mesh
     std::filesystem::path mesh_path{std::string(ENGINE_ASSETS_DIR) + "/four_bunny/four_bunny.obj"};
     std::shared_ptr tmc = std::make_shared<MeshComponentFromFile>(mesh_path);
-    rsys->RegisterComponent(tmc);
+    rsys->GetRendererManager().RegisterRendererComponent(tmc);
 
     // Setup camera
     Transform transform{};
@@ -327,7 +327,7 @@ int main(int argc, char **argv) {
             depth_att,
             extent
         );
-        rsys->DrawMeshes();
+        cb.DrawRenderers(rsys->GetRendererManager().FilterAndSortRenderers({}), 0);
         cb.EndRendering();
 
         context.UseImage(
@@ -364,7 +364,6 @@ int main(int argc, char **argv) {
         frame_count * 1.0 / duration_time
     );
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "Unloading Main-class");
     return 0;

--- a/test/complex_mesh_test.cpp
+++ b/test/complex_mesh_test.cpp
@@ -126,11 +126,6 @@ public:
         auto system = m_system.lock();
         auto &helper = system->GetFrameManager().GetSubmissionHelper();
 
-        for (auto &submesh : m_submeshes) {
-            submesh->Prepare();
-            helper.EnqueueVertexBufferSubmission(*submesh);
-        }
-
         for (size_t i = 0; i < m_material_assets.size(); i++) {
             auto ptr = std::make_shared<Materials::BlinnPhongInstance>(
                 *system, system->GetMaterialRegistry().GetMaterial("Built-in Blinn-Phong")

--- a/test/constant_data_test.cpp
+++ b/test/constant_data_test.cpp
@@ -51,7 +51,6 @@ int main(int, char **) {
     uint32_t total_test_frame = MAXIMUM_FRAME_COUNT;
 
     TestHomoMesh mesh{system};
-    mesh.Prepare();
 
     ConstantData::PerCameraStruct transform{glm::mat4{1.0f}, glm::mat4{1.0f}};
 

--- a/test/flag_bits_test.cpp
+++ b/test/flag_bits_test.cpp
@@ -1,0 +1,50 @@
+#include <cassert>
+#include "engine/Core/flagbits.h"
+
+enum class Bits {
+    a = 0b0001,
+    b = 0b0010,
+    c = 0b0100,
+    d = 0b1000
+};
+
+using Flag = Engine::Flags<Bits>;
+
+int main () {
+    Flag flagdefault{};
+    Flag flaga{Bits::a}, flagb{Bits::b}, flagc{Bits::c}, flagd{Bits::d};
+    Flag flagab{Bits::a, Bits::b};
+   
+    assert(!flagdefault);
+    assert(flagab & flaga);
+    assert(flagab & Bits::b);
+
+    auto flg{flagab | flagc};
+    assert(flg & Bits::a);
+    assert(flg & Bits::b);
+    assert(flg & Bits::c);
+    assert(!(flg & Bits::d));
+
+    flg = {flagab | Bits::c};
+    assert(flg & flaga);
+    assert(flg & flagb);
+    assert(flg & flagc);
+    assert(!(flg & flagd));
+
+    flg = flagab;
+    flg &= Bits::a;
+    assert(flg == Flag{Bits::a});
+
+    flg = flagab;
+    flg &= flaga;
+    assert(flg == flaga);
+
+    flg |= Bits::b;
+    assert(flg == flagab);
+    flg |= flagb;
+    assert(flg == flagab);
+
+    flg = ~flg;
+    assert(flg & Bits::d);
+    assert(!(flg & Bits::a));
+}

--- a/test/flag_bits_test.cpp
+++ b/test/flag_bits_test.cpp
@@ -47,4 +47,14 @@ int main () {
     flg = ~flg;
     assert(flg & Bits::d);
     assert(!(flg & Bits::a));
+
+    Flag f;
+    f.Set(Bits::a);
+    f.Set(Bits::b);
+    f.Mask(Bits::c);
+    assert(!f);
+
+    f.Set(Bits::a);
+    assert(f.Test(Bits::a));
+    assert(!f.Test(Bits::b));
 }

--- a/test/flag_bits_test.cpp
+++ b/test/flag_bits_test.cpp
@@ -1,5 +1,5 @@
-#include <cassert>
 #include "engine/Core/flagbits.h"
+#include <cassert>
 
 enum class Bits {
     a = 0b0001,
@@ -10,11 +10,11 @@ enum class Bits {
 
 using Flag = Engine::Flags<Bits>;
 
-int main () {
+int main() {
     Flag flagdefault{};
     Flag flaga{Bits::a}, flagb{Bits::b}, flagc{Bits::c}, flagd{Bits::d};
     Flag flagab{Bits::a, Bits::b};
-   
+
     assert(!flagdefault);
     assert(flagab & flaga);
     assert(flagab & Bits::b);

--- a/test/image_read_test.cpp
+++ b/test/image_read_test.cpp
@@ -58,7 +58,6 @@ int main(int, char *[]) {
     uint32_t total_test_frame = 144;
 
     TestHomoMesh mesh{render_system};
-    mesh.Prepare();
 
     int tex_width, tex_height, tex_channel;
     std::filesystem::path image_path{ENGINE_ROOT_DIR};

--- a/test/imgui_test.cpp
+++ b/test/imgui_test.cpp
@@ -104,7 +104,6 @@ int main(int argc, char **argv) {
     }
 
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     return 0;
 }

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -29,7 +29,7 @@ struct LowerPlaneMeshAsset : public MeshAsset {
                     {-0.5f, 0.5f, 0.0f},
                     {-0.5f, -0.5f, 0.0f},
                 },
-            .m_attributes = {
+            .m_attributes_basic = {
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {1.0f, 0.0f}},
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {1.0f, 1.0f}},
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {0.0f, 1.0f}},

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -275,7 +275,6 @@ int main(int argc, char **argv) {
     }
 
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     return 0;
 }

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -105,7 +105,6 @@ int main(int argc, char **argv) {
     auto test_mesh_asset = std::make_shared<LowerPlaneMeshAsset>();
     auto test_mesh_asset_ref = std::make_shared<AssetRef>(test_mesh_asset);
     HomogeneousMesh test_mesh{rsys, test_mesh_asset_ref, 0};
-    test_mesh.Prepare();
 
     // Submit scene data
     const auto &global_pool = rsys->GetGlobalConstantDescriptorPool();

--- a/test/pbr_test.cpp
+++ b/test/pbr_test.cpp
@@ -146,11 +146,6 @@ public:
         auto system = m_system.lock();
         auto &helper = system->GetFrameManager().GetSubmissionHelper();
 
-        for (auto &submesh : m_submeshes) {
-            submesh->Prepare();
-            helper.EnqueueVertexBufferSubmission(*submesh);
-        }
-
         auto id_albedo = material_template->GetVariableIndex("albedoSampler", 0).value();
         assert(id_albedo.second == false);
         for (size_t i = 0; i < m_submeshes.size(); i++) {

--- a/test/pbr_test.cpp
+++ b/test/pbr_test.cpp
@@ -323,7 +323,7 @@ int main(int argc, char **argv) {
     // Setup mesh
     std::filesystem::path mesh_path{std::string(ENGINE_ASSETS_DIR) + "/sphere/sphere.obj"};
     std::shared_ptr tmc = std::make_shared<MeshComponentFromFile>(mesh_path, pbr_material_template, red_texture);
-    rsys->RegisterComponent(tmc);
+    rsys->GetRendererManager().RegisterRendererComponent(tmc);
 
     // Setup camera
     Transform transform{};
@@ -376,7 +376,7 @@ int main(int argc, char **argv) {
         context.PrepareCommandBuffer();
         vk::Extent2D extent{rsys->GetSwapchain().GetExtent()};
         cb.BeginRendering(color_att, depth_att, extent);
-        rsys->DrawMeshes();
+        cb.DrawRenderers(rsys->GetRendererManager().FilterAndSortRenderers({}), 0);
         cb.EndRendering();
 
         auto cctx = rsys->GetFrameManager().GetComputeContext();
@@ -431,7 +431,6 @@ int main(int argc, char **argv) {
         frame_count * 1.0 / duration_time
     );
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "Unloading Main-class");
     return 0;

--- a/test/shadow_map_test.cpp
+++ b/test/shadow_map_test.cpp
@@ -111,12 +111,10 @@ int main(int argc, char **argv) {
     auto test_mesh_asset = std::make_shared<LowerPlaneMeshAsset>();
     auto test_mesh_asset_ref = std::make_shared<AssetRef>(test_mesh_asset);
     HomogeneousMesh test_mesh{rsys, test_mesh_asset_ref, 0};
-    test_mesh.Prepare();
 
     auto test_mesh_asset_2 = std::make_shared<HighPlaneMeshAsset>();
     auto test_mesh_asset_2_ref = std::make_shared<AssetRef>(test_mesh_asset_2);
     HomogeneousMesh test_mesh_2{rsys, test_mesh_asset_2_ref, 0};
-    test_mesh_2.Prepare();
 
     // Submit scene data
     const auto &global_pool = rsys->GetGlobalConstantDescriptorPool();

--- a/test/shadow_map_test.cpp
+++ b/test/shadow_map_test.cpp
@@ -29,7 +29,7 @@ struct LowerPlaneMeshAsset : public MeshAsset {
                     {-1.0f, 1.0f, 0.5f},
                     {-1.0f, -1.0f, 0.5f},
                 },
-            .m_attributes = {
+            .m_attributes_basic = {
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {1.0f, 0.0f}},
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {1.0f, 1.0f}},
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {0.0f, 1.0f}},
@@ -51,7 +51,7 @@ struct HighPlaneMeshAsset : public MeshAsset {
                     {-0.5f, 0.5f, 0.0f},
                     {-0.5f, -0.5f, 0.0f},
                 },
-            .m_attributes = {
+            .m_attributes_basic = {
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {1.0f, 0.0f}},
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {1.0f, 1.0f}},
                 {.color = {1.0f, 1.0f, 1.0f}, .normal = {0.0f, 0.0f, -1.0f}, .texcoord1 = {0.0f, 1.0f}},

--- a/test/shadow_map_test.cpp
+++ b/test/shadow_map_test.cpp
@@ -320,7 +320,6 @@ int main(int argc, char **argv) {
     }
 
     rsys->WaitForIdle();
-    rsys->ClearComponent();
 
     return 0;
 }

--- a/test/vulkan_init_test.cpp
+++ b/test/vulkan_init_test.cpp
@@ -114,7 +114,6 @@ int main(int, char **) {
     double duration_time = 1.0 * duration / SDL_GetPerformanceFrequency();
     SDL_LogInfo(0, "Took %lf seconds for 200 frames (avg. %lf fps).", duration_time, 200.0 / duration_time);
     system->WaitForIdle();
-    system->ClearComponent();
 
     SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "Unloading Main-class");
     return 0;


### PR DESCRIPTION
This PR consists of the first part of the Mesh Rework which resolves #48. It brings in a `RendererManager` to help manage filtering and sorting of the renderers and their submission to the device, relieving such functionalities from `RenderSystem`. It further provides a refactor of `HomogeneousMesh` to enable future support varied combination of vertex attributes.

Future work includes a complete refactor of mesh (and possibly texture and buffer) memory management, introducing a data-oriented framework, and a new pipeline dispatch scheme to allow rendering of different type of meshes.