### PR TITLE
Flexible pipeline functionality

### DIFF
--- a/engine/Asset/Material/MaterialTemplateAsset.h
+++ b/engine/Asset/Material/MaterialTemplateAsset.h
@@ -31,7 +31,7 @@ namespace Engine {
     /// material, and are stored in this struct or left as default. And these are either fixed or filled in at run-time:
     /// 2nd and 3rd, which are decided based on the mesh to be drawn;
     /// 5th, which is always dynamic and unspecified until rendering;
-    /// 7th, which is always disabled due to poor compatibility with deferred rendering;
+    /// 7th, which is always determined by attachment samples at runtime;
     /// 10th, which is always fixed to be viewports and scissors.
     struct REFL_SER_CLASS(REFL_WHITELIST) MaterialTemplateSinglePassProperties {
         REFL_SER_BODY(MaterialTemplateSinglePassProperties)
@@ -43,6 +43,7 @@ namespace Engine {
         using DSProperties = PipelineProperties::DSProperties;
         using Shaders = PipelineProperties::Shaders;
         using Attachments = PipelineProperties::Attachments;
+        using Multisampling = PipelineProperties::Multisampling;
 
         /// @brief C.f. `vkPipelineRasterizationStateCreateInfo`
         REFL_SER_ENABLE RasterizerProperties rasterizer{};
@@ -56,6 +57,9 @@ namespace Engine {
         /// @brief C.f. `vkPipelineRenderingCreateInfo`
         /// Use UNDEFINED image format to adapt to swapchain.
         REFL_SER_ENABLE Attachments attachments{};
+
+        /// @brief C.f. `vkPipelineMultisampleStateCreateInfo`
+        REFL_SER_ENABLE Multisampling multisampling{};
 
         // XXX: We had better support pipeline caches to speed up loading...
         // C.f. `vkGetPipelineCacheData`

--- a/engine/Asset/Material/PipelineProperty.h
+++ b/engine/Asset/Material/PipelineProperty.h
@@ -188,6 +188,26 @@ namespace Engine {
             ImageUtils::ImageFormat depth{};
             ImageUtils::ImageFormat stencil{};
         };
+
+        /**
+         * @brief c.f. `vkPipelineMultisampleStateCreateInfo`
+         * While how many samples are used are determined at run-time, this
+         * struct controls how some techniques are used. If multisampling are
+         * not actually used, how these techniques perform is
+         * implementation-defined.
+         */
+        struct REFL_SER_CLASS(REFL_BLACKLIST) Multisampling {
+            REFL_SER_SIMPLE_STRUCT(Multisampling)
+            /**
+             * Enable alpha-to-coverage technique for multisampling.
+             */
+            bool alpha_to_coverage_enable{false};
+            /**
+             * Write one to alpha channel after multisampling.
+             * It should be combined with alpha-to-coverage technique.
+             */
+            bool alpha_to_one_enable{false};
+        };
     } // namespace PipelineProperties
 } // namespace Engine
 

--- a/engine/Asset/Mesh/MeshAsset.h
+++ b/engine/Asset/Mesh/MeshAsset.h
@@ -25,7 +25,7 @@ namespace Engine {
             std::vector<uint32_t> m_indices{};
 
             // Raw buffer containing all vertex attribute data
-            std::vector <std::byte> m_vertex_attributes;
+            std::vector <std::byte> m_vertex_attributes {};
 
             struct Attributes {
                 VertexAttributeType type{VertexAttributeType::Unused};

--- a/engine/MainClass.cpp
+++ b/engine/MainClass.cpp
@@ -230,7 +230,7 @@ namespace Engine {
         this->renderer->GetCameraManager().SetActiveCameraIndex(this->world->GetActiveCamera()->m_display_id);
 
         renderer->GetSceneDataManager().DrawSkybox(
-            renderer->GetFrameManager().GetRawMainCommandBuffer(),
+            cb,
             renderer->GetFrameManager().GetFrameInFlight(),
             world->GetActiveCamera()->GetViewMatrix(),
             world->GetActiveCamera()->GetProjectionMatrix()

--- a/engine/Render/Hasher.hpp
+++ b/engine/Render/Hasher.hpp
@@ -78,6 +78,21 @@ namespace Engine {
             );
         }
 
+        /**
+         * @brief Convert any type by bit to `uint32_t` or `uint64_t` and hash
+         * the converted integer.
+         */
+        template <typename T>
+        inline void any(const T & a) {
+            if constexpr (sizeof(T) == sizeof(uint32_t)) {
+                u32(std::bit_cast<uint32_t>(a));
+            } else if constexpr (sizeof(T) == sizeof(uint64_t)) {
+                u64(std::bit_cast<uint64_t>(a));
+            } else {
+                static_assert(false, "Failed to convert T to uint32_t or uint64_t");
+            }
+        }
+
         inline void string(const char *str) noexcept {
             char c;
             u32(0xff);

--- a/engine/Render/Memory/ComputeBuffer.h
+++ b/engine/Render/Memory/ComputeBuffer.h
@@ -33,7 +33,7 @@ namespace Engine {
 
     template <class T>
     class ComputeBufferTyped {
-        std::unique_ptr <ComputeBuffer> buffer;
+        std::unique_ptr <ComputeBuffer> buffer {};
     public:
         /**
          * @brief Create a new compute buffer.

--- a/engine/Render/Memory/Texture.cpp
+++ b/engine/Render/Memory/Texture.cpp
@@ -80,7 +80,7 @@ namespace Engine {
         std::unordered_map <
             TextureSubresourceRange,
             vk::UniqueImageView,
-            subresource_hasher> m_views;
+            subresource_hasher> m_views {};
 
         vk::Sampler m_sampler {};
         std::string m_name {};

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.cpp
@@ -31,11 +31,14 @@ namespace Engine {
         vk::Extent2D extent,
         const std::string &name
     ) {
-        DEBUG_CMD_START_LABEL(cb, name.c_str());
         std::vector<vk::RenderingAttachmentInfo> color_attachment;
 
         if (color.texture) {
             color_attachment.push_back(GetVkAttachmentInfo(color, vk::ImageLayout::eColorAttachmentOptimal));
+            m_pripr.color_attachment_format[0] = color.texture->GetTextureDescription().format;
+            m_pripr.color_attachment_format[1] = ImageUtils::ImageFormat::UNDEFINED;
+        } else {
+            m_pripr.color_attachment_format[0] = ImageUtils::ImageFormat::UNDEFINED;
         }
 
         vk::RenderingAttachmentInfo depth_attachment;
@@ -43,7 +46,9 @@ namespace Engine {
             depth_attachment = vk::RenderingAttachmentInfo{
                 GetVkAttachmentInfo(depth, vk::ImageLayout::eDepthStencilAttachmentOptimal)
             };
+            m_pripr.depth_stencil_attachment_format = depth.texture->GetTextureDescription().format;
         } else {
+            m_pripr.depth_stencil_attachment_format = ImageUtils::ImageFormat::UNDEFINED;
         }
 
         vk::RenderingInfo info{
@@ -55,7 +60,7 @@ namespace Engine {
             depth.texture ? &depth_attachment : nullptr,
             nullptr
         };
-        // Begin rendering after transit
+        DEBUG_CMD_START_LABEL(cb, name.c_str());
         cb.beginRendering(info);
     }
 
@@ -65,16 +70,22 @@ namespace Engine {
         vk::Extent2D extent,
         const std::string &name
     ) {
-        DEBUG_CMD_START_LABEL(cb, name.c_str());
-
         std::vector<vk::RenderingAttachmentInfo> color_attachment_info(colors.size(), vk::RenderingAttachmentInfo{});
+        assert(colors.size() < 8 && "At most 8 color rendering targets are supported.");
         for (size_t i = 0; i < colors.size(); i++) {
             color_attachment_info[i] = GetVkAttachmentInfo(colors[i], vk::ImageLayout::eColorAttachmentOptimal);
+            m_pripr.color_attachment_format[i] = colors[i].texture->GetTextureDescription().format;
+        }
+        if (colors.size() < 8) {
+            m_pripr.color_attachment_format[colors.size()] = ImageUtils::ImageFormat::UNDEFINED;
         }
 
         vk::RenderingAttachmentInfo depth_attachment_info{};
         if (depth.texture) {
             depth_attachment_info = GetVkAttachmentInfo(depth, vk::ImageLayout::eDepthStencilAttachmentOptimal);
+            m_pripr.depth_stencil_attachment_format = depth.texture->GetTextureDescription().format;
+        } else {
+            m_pripr.depth_stencil_attachment_format = ImageUtils::ImageFormat::UNDEFINED;
         }
 
         vk::RenderingInfo info{
@@ -86,6 +97,8 @@ namespace Engine {
             depth.texture ? &depth_attachment_info : nullptr,
             nullptr
         };
+
+        DEBUG_CMD_START_LABEL(cb, name.c_str());
         cb.beginRendering(info);
     }
 
@@ -218,7 +231,13 @@ namespace Engine {
             glm::mat4 model_matrix = m_system.GetRendererManager().GetRendererComponent(rid)->GetWorldTransform().GetTransformMatrix();
             auto material_instance = m_system.GetRendererManager().GetMaterialInstance(rid);
 
-            auto tpl = material_instance->GetLibrary().FindMaterialTemplate(tag, mesh->GetVertexAttributeFormat());
+            auto tpl = material_instance->GetLibrary().FindMaterialTemplate(
+                tag,
+                {
+                    {mesh->GetVertexAttributeFormat()},
+                    m_pripr
+                }
+            );
             if (!tpl)   continue;
 
             this->BindMaterial(*material_instance, *tpl);
@@ -229,6 +248,8 @@ namespace Engine {
     void GraphicsCommandBuffer::EndRendering() {
         cb.endRendering();
         DEBUG_CMD_END_LABEL(cb);
+
+        m_pripr = {};
     }
 
     void GraphicsCommandBuffer::DrawMesh(const IVertexBasedRenderer &mesh) {

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
@@ -1,6 +1,7 @@
 #ifndef PIPELINE_COMMANDBUFFER_GRAPHICSCOMMANDBUFFER_INCLUDED
 #define PIPELINE_COMMANDBUFFER_GRAPHICSCOMMANDBUFFER_INCLUDED
 
+#include "Render/Pipeline/PipelineRuntimeInfo.h"
 #include "Render/Pipeline/CommandBuffer/TransferCommandBuffer.h"
 #include "Render/RenderSystem/RendererManager.h"
 
@@ -124,7 +125,10 @@ namespace Engine {
          * 
          * The camera index used in rendering is assumed to be the current active camera.
          */
-        void DrawRenderers(const std::string & tag, const RendererList &renderers);
+        void DrawRenderers(
+            const std::string & tag,
+            const RendererList &renderers
+        );
 
         /**
          * @brief Draw renderers in the RendererList with specified pass index.
@@ -144,7 +148,12 @@ namespace Engine {
     protected:
         RenderSystem & m_system;
         uint32_t m_inflight_frame_index;
-        std::optional<std::pair<vk::Pipeline, vk::PipelineLayout>> m_bound_material_pipeline{};
+
+        std::optional<
+            std::pair<vk::Pipeline, vk::PipelineLayout>
+        > m_bound_material_pipeline{};
+
+        PipelineRuntimeInfoPerRendering m_pripr{};
     };
 } // namespace Engine
 

--- a/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
+++ b/engine/Render/Pipeline/CommandBuffer/GraphicsCommandBuffer.h
@@ -69,6 +69,20 @@ namespace Engine {
             const std::string & name = ""
         );
 
+        /**
+         * @brief Set up pipeline runtime info.
+         */
+        void SetRenderingInfo (PipelineRuntimeInfoPerRendering pripr) noexcept {
+            m_pripr = pripr;
+        }
+
+        /**
+         * @brief Get pipeline runtime info.
+         */
+        const PipelineRuntimeInfoPerRendering & GetRenderingInfo() const noexcept {
+            return m_pripr;
+        }
+
          /**
          * @brief Bind per scene resources to the command buffer.
          * 

--- a/engine/Render/Pipeline/Material/MaterialInstance.cpp
+++ b/engine/Render/Pipeline/Material/MaterialInstance.cpp
@@ -235,9 +235,9 @@ namespace Engine {
     }
 
     std::vector <uint32_t> MaterialInstance::UpdateGPUInfo(
-        const std::string &tag, VertexAttribute type, uint32_t backbuffer
+        const std::string &tag, const PipelineRuntimeInfo & pri, uint32_t backbuffer
     ) {
-        auto tpl = GetLibrary().FindMaterialTemplate(tag, type);
+        auto tpl = GetLibrary().FindMaterialTemplate(tag, pri);
         assert(tpl);
         return this->UpdateGPUInfo(*tpl, backbuffer);
     }
@@ -252,11 +252,11 @@ namespace Engine {
     }
 
     vk::DescriptorSet MaterialInstance::GetDescriptor(
-        const std::string &tag, VertexAttribute type, uint32_t backbuffer
+        const std::string &tag, const PipelineRuntimeInfo & pri, uint32_t backbuffer
     ) const noexcept {
         assert(backbuffer < impl::PassInfo::BACK_BUFFERS);
 
-        auto tpl = GetLibrary().FindMaterialTemplate(tag, type);
+        auto tpl = GetLibrary().FindMaterialTemplate(tag, pri);
         assert(tpl);
         return this->GetDescriptor(*tpl, backbuffer);
     }

--- a/engine/Render/Pipeline/Material/MaterialInstance.h
+++ b/engine/Render/Pipeline/Material/MaterialInstance.h
@@ -68,7 +68,7 @@ namespace Engine {
         );
         std::vector <uint32_t> UpdateGPUInfo(
             const std::string & tag,
-            VertexAttribute type,
+            const PipelineRuntimeInfo & pri,
             uint32_t backbuffer
         );
 
@@ -92,7 +92,7 @@ namespace Engine {
         ) const noexcept;
         vk::DescriptorSet GetDescriptor(
             const std::string & tag,
-            VertexAttribute type,
+            const PipelineRuntimeInfo & pri,
             uint32_t backbuffer
         ) const noexcept;
 

--- a/engine/Render/Pipeline/Material/MaterialLibrary.cpp
+++ b/engine/Render/Pipeline/Material/MaterialLibrary.cpp
@@ -23,7 +23,6 @@ namespace Engine {
         };
 
         struct PipelineAssetItem {
-            MeshVertexType expected_mesh_type {};
             std::shared_ptr<AssetRef> material_template_asset {};
         };
 
@@ -211,8 +210,8 @@ namespace Engine {
                     shader_modules,
                     b.pipeline_layout,
                     b.descriptor_pool.get(),
-                    &b.reflected,
-                    VertexAttribute{pri.va},
+                    b.reflected,
+                    pri,
                     asset->name
                 );
             } else {
@@ -222,8 +221,8 @@ namespace Engine {
                     shader_modules,
                     b.pipeline_layout,
                     nullptr,
-                    &b.reflected,
-                    VertexAttribute{pri.va},
+                    b.reflected,
+                    pri,
                     asset->name
                 );
             }
@@ -241,10 +240,8 @@ namespace Engine {
     MaterialLibrary::~MaterialLibrary() {
     }
     const MaterialTemplate * MaterialLibrary::FindMaterialTemplate(
-        const std::string &tag, VertexAttribute mesh_type
+        const std::string &tag, const PipelineRuntimeInfo & pri
     ) const noexcept {
-        auto pri = PipelineRuntimeInfo{ {.va = mesh_type}, {} };
-
         auto itr = pimpl->pipeline_table.find(tag);
         if (itr != pimpl->pipeline_table.end() && itr->second.materials[pri]) {
             return itr->second.materials[pri].get();
@@ -274,16 +271,15 @@ namespace Engine {
     }
 
     MaterialTemplate *MaterialLibrary::FindMaterialTemplate(
-        const std::string &tag, VertexAttribute mesh_type
+        const std::string &tag, const PipelineRuntimeInfo & pri
     ) noexcept {
-        return const_cast<MaterialTemplate *>(std::as_const(*this).FindMaterialTemplate(tag, mesh_type));
+        return const_cast<MaterialTemplate *>(std::as_const(*this).FindMaterialTemplate(tag, pri));
     }
 
     void MaterialLibrary::Instantiate(const MaterialLibraryAsset & asset) {
         pimpl->pipeline_table.clear();
         for (auto & [tag, bundle] : asset.material_bundle) {
             pimpl->pipeline_asset_table[tag] = impl::PipelineAssetItem{
-                .expected_mesh_type = static_cast<MeshVertexType>(bundle.expected_mesh_type),
                 .material_template_asset = bundle.material_template
             };
         }

--- a/engine/Render/Pipeline/Material/MaterialLibrary.cpp
+++ b/engine/Render/Pipeline/Material/MaterialLibrary.cpp
@@ -1,6 +1,7 @@
 #include "MaterialLibrary.h"
 
-#include "Render/Renderer/VertexAttribute.h"
+#include "Render/Pipeline/PipelineRuntimeInfo.h"
+#include "Render/Pipeline/PipelineUtils.hpp"
 #include "Asset/Material/MaterialTemplateAsset.h"
 #include "Render/DebugUtils.h"
 #include "Render/Memory/ShaderParameters/ShaderParameterLayout.h"
@@ -39,7 +40,11 @@ namespace Engine {
             /// Material pipeline layout.
             vk::PipelineLayout pipeline_layout{};
 
-            std::unordered_map <uint64_t, std::unique_ptr<MaterialTemplate>> materials{};
+            std::unordered_map <
+                PipelineRuntimeInfo,
+                std::unique_ptr<MaterialTemplate>,
+                PipelineUtils::pipeline_runtime_info_hasher
+            > materials{};
         };
 
         std::unordered_map <std::string, PipelineBundle> pipeline_table {};
@@ -48,13 +53,13 @@ namespace Engine {
         MaterialTemplate & GetPipelineOrCreate(
             RenderSystem & system,
             const std::string & tag,
-            uint64_t mesh_type
+            const PipelineRuntimeInfo & pri
         ) {
             auto itr = pipeline_table.find(tag);
-            if (itr == pipeline_table.end() || !(itr->second.materials[mesh_type])) {
-                CreatePipeline(system, tag, mesh_type);
+            if (itr == pipeline_table.end() || !(itr->second.materials[pri])) {
+                CreatePipeline(system, tag, pri);
             }
-            return *pipeline_table[tag].materials[mesh_type];
+            return *pipeline_table[tag].materials[pri];
         }
 
         void CompileShaderModules (
@@ -160,26 +165,18 @@ namespace Engine {
 
         /**
          * @brief Create a pipeline, assuming that the asset corresponding to
-         * both the tag and the mesh type exists.
+         * both the tag and the runtime information.
          */
-        void CreatePipeline(RenderSystem & system, const std::string & tag, uint64_t actual_type) {
+        void CreatePipeline(
+            RenderSystem & system,
+            const std::string & tag,
+            const PipelineRuntimeInfo & pri
+        ) {
             auto itr = pipeline_asset_table.find(tag);
             assert(itr != pipeline_asset_table.end() && "Pipeline tag not found.");
             assert(itr->second.material_template_asset && "Invalid material template asset.");
             
-            auto expected_type = static_cast<uint64_t>(itr->second.expected_mesh_type);
             const auto & asset = itr->second.material_template_asset->cas<const MaterialTemplateAsset>();
-
-            SDL_LogInfo(
-                SDL_LOG_CATEGORY_RENDER,
-                std::format(
-                    "Creating material (name: {}, type: {} -> {}) from asset {}.",
-                    tag,
-                    expected_type,
-                    actual_type,
-                    asset->name
-                ).c_str()
-            );
 
             if (pipeline_table[tag].shader_modules.empty()) {
                 CompileShaderModules(
@@ -208,25 +205,25 @@ namespace Engine {
                 }
             );
             if (b.descriptor_pool) {
-                pipeline_table[tag].materials[actual_type] = std::make_unique<MaterialTemplate>(
+                pipeline_table[tag].materials[pri] = std::make_unique<MaterialTemplate>(
                     system,
                     asset->properties,
                     shader_modules,
                     b.pipeline_layout,
                     b.descriptor_pool.get(),
                     &b.reflected,
-                    VertexAttribute{.packed = actual_type},
+                    VertexAttribute{pri.va},
                     asset->name
                 );
             } else {
-                pipeline_table[tag].materials[actual_type] = std::make_unique<MaterialTemplate>(
+                pipeline_table[tag].materials[pri] = std::make_unique<MaterialTemplate>(
                     system,
                     asset->properties,
                     shader_modules,
                     b.pipeline_layout,
                     nullptr,
                     &b.reflected,
-                    VertexAttribute{.packed = actual_type},
+                    VertexAttribute{pri.va},
                     asset->name
                 );
             }
@@ -234,7 +231,7 @@ namespace Engine {
             SDL_LogInfo(
                 SDL_LOG_CATEGORY_RENDER,
                 "Created material %p.",
-                static_cast<void *>(pipeline_table[tag].materials[actual_type].get())
+                static_cast<void *>(pipeline_table[tag].materials[pri].get())
             );
         }
     };
@@ -246,11 +243,11 @@ namespace Engine {
     const MaterialTemplate * MaterialLibrary::FindMaterialTemplate(
         const std::string &tag, VertexAttribute mesh_type
     ) const noexcept {
-        auto idx = mesh_type.packed;
+        auto pri = PipelineRuntimeInfo{ {.va = mesh_type}, {} };
 
         auto itr = pimpl->pipeline_table.find(tag);
-        if (itr != pimpl->pipeline_table.end() && itr->second.materials[idx]) {
-            return itr->second.materials[idx].get();
+        if (itr != pimpl->pipeline_table.end() && itr->second.materials[pri]) {
+            return itr->second.materials[pri].get();
         }
         if (itr == pimpl->pipeline_table.end()) {
             auto inserted = pimpl->pipeline_table.insert({tag, impl::PipelineBundle{}});
@@ -268,18 +265,12 @@ namespace Engine {
             );
             return nullptr;
         }
-        // Find lowest available asset
-        auto asset_ptr = asset_itr->second.material_template_asset;
-        uint64_t available_idx = static_cast<uint64_t>(asset_itr->second.expected_mesh_type);
-        // Construct material from compatible material.
-        if (available_idx != idx) {
-            SDL_LogWarn(
-                SDL_LOG_CATEGORY_RENDER,
-                "Pipeline tagged %s found, but mesh type %llu is not available, and is downgraded to %llu.",
-                tag.c_str(), idx, available_idx
-            );
-        }
-        return &pimpl->GetPipelineOrCreate(m_system, tag, idx);
+
+        return &pimpl->GetPipelineOrCreate(
+            m_system,
+            tag,
+            pri
+        );
     }
 
     MaterialTemplate *MaterialLibrary::FindMaterialTemplate(

--- a/engine/Render/Pipeline/Material/MaterialLibrary.h
+++ b/engine/Render/Pipeline/Material/MaterialLibrary.h
@@ -6,6 +6,7 @@
 #include "Asset/InstantiatedFromAsset.h"
 #include "Asset/Material/MaterialLibraryAsset.h"
 #include "Render/Renderer/VertexAttribute.h"
+#include "Render/Pipeline/PipelineRuntimeInfo.h"
 
 namespace Engine {
 
@@ -47,12 +48,11 @@ namespace Engine {
          */
         const MaterialTemplate * FindMaterialTemplate(
             const std::string & tag,
-            VertexAttribute mesh_type
+            const PipelineRuntimeInfo & pri
         ) const noexcept;
-
         MaterialTemplate * FindMaterialTemplate(
             const std::string & tag,
-            VertexAttribute mesh_type
+            const PipelineRuntimeInfo & pri
         ) noexcept;
 
         void PreheatMaterialTemplate(

--- a/engine/Render/Pipeline/Material/MaterialTemplate.cpp
+++ b/engine/Render/Pipeline/Material/MaterialTemplate.cpp
@@ -96,6 +96,34 @@ namespace Engine {
                 && "Mismatched color attachment and blending operation size."
             );
 
+            std::vector<vk::PipelineColorBlendAttachmentState> cbass{
+                PipelineUtils::ToVulkanColorBlendingOps(prop.attachments.color_blending)
+            };
+
+            if (color_attachment_formats.size() < cbass.size()) {
+                SDL_LogWarn(
+                    SDL_LOG_CATEGORY_RENDER,
+                    "For material %s, %llu color render targets are requested, but only %llu are provided. "
+                    "Shader writes to extra color attachments will be discarded.",
+                    m_name.c_str(),
+                    color_attachment_formats.size(),
+                    cbass.size()
+                );
+                cbass.resize(color_attachment_formats.size());
+            } else if (color_attachment_formats.size() > cbass.size()) {
+                SDL_LogWarn(
+                    SDL_LOG_CATEGORY_RENDER,
+                    "For material %s, %llu color render targets are requested, but only %llu are provided. "
+                    "Extra color render targets will not be written in the shader.",
+                    m_name.c_str(),
+                    color_attachment_formats.size(),
+                    cbass.size()
+                );
+                for (auto i = cbass.size(); i < color_attachment_formats.size(); i++) {
+                    cbass.push_back(vk::PipelineColorBlendAttachmentState{});
+                }
+            }
+
             prci = vk::PipelineRenderingCreateInfo{
                 0,
                 color_attachment_formats,
@@ -103,11 +131,7 @@ namespace Engine {
                 // XXX: stencil attachment support
                 vk::Format::eUndefined
             };
-
             cbsi.logicOpEnable = vk::False;
-            std::vector<vk::PipelineColorBlendAttachmentState> cbass{
-                PipelineUtils::ToVulkanColorBlendingOps(prop.attachments.color_blending)
-            };
             cbsi.setAttachments(cbass);
 
             vk::GraphicsPipelineCreateInfo gpci{};

--- a/engine/Render/Pipeline/Material/MaterialTemplate.cpp
+++ b/engine/Render/Pipeline/Material/MaterialTemplate.cpp
@@ -68,9 +68,6 @@ namespace Engine {
                 }
             }
 
-            bool use_swapchain_attachments =
-                prop.attachments.color.empty() && prop.attachments.depth == ImageUtils::ImageFormat::UNDEFINED;
-
             auto vertex_bindings = pri.va.ToVkVertexInputBinding();
             auto vertex_attribute = pri.va.ToVkVertexAttribute();
             auto vis = vk::PipelineVertexInputStateCreateInfo{
@@ -87,62 +84,30 @@ namespace Engine {
 
             vk::PipelineColorBlendStateCreateInfo cbsi{};
             vk::PipelineRenderingCreateInfo prci{};
-            std::vector<vk::PipelineColorBlendAttachmentState> cbass;
 
-            vk::Format default_color_format{system.GetSwapchain().GetColorFormat()};
+            std::vector<vk::Format> color_attachment_formats{};
 
-            std::vector<vk::Format> color_attachment_formats{prop.attachments.color.size(), vk::Format::eUndefined};
-            // Fill in attachment information
-            if (use_swapchain_attachments) {
-                SDL_LogWarn(
-                    SDL_LOG_CATEGORY_RENDER,
-                    "Material template \"%s\" does not specify its color attachment format. "
-                    "Falling back to Swapchain default format. Gamma correction and color space may be incorrect.",
-                    m_name.c_str()
-                );
-
-                color_attachment_formats = {default_color_format};
-
-                prci = vk::PipelineRenderingCreateInfo{
-                    0, color_attachment_formats, vk::Format::eUndefined, vk::Format::eUndefined
-                };
-                cbass.push_back(
-                    vk::PipelineColorBlendAttachmentState{
-                        vk::False,
-                        vk::BlendFactor::eSrcAlpha,
-                        vk::BlendFactor::eOneMinusSrcAlpha,
-                        vk::BlendOp::eAdd,
-                        vk::BlendFactor::eOne,
-                        vk::BlendFactor::eZero,
-                        vk::BlendOp::eAdd,
-                        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB
-                            | vk::ColorComponentFlagBits::eA
-                    }
-                );
-            } else if (prop.attachments.color.empty() && prop.attachments.depth != ImageUtils::ImageFormat::UNDEFINED) {
-                // Has depth attachment with no color attachments => depth-only
-                prci = vk::PipelineRenderingCreateInfo{
-                    0, 0, nullptr, ImageUtils::GetVkFormat(prop.attachments.depth), vk::Format::eUndefined, nullptr
-                };
-            } else {
-                // All custom attachments
-                assert(
-                    prop.attachments.color.size() == prop.attachments.color_blending.size()
-                    && "Mismatched color attachment and blending operation size."
-                );
-
-                cbass = PipelineUtils::ToVulkanColorBlendingOps(prop.attachments.color_blending);
-                color_attachment_formats = PipelineUtils::ToVulkanFormat(prop.attachments.color, default_color_format);
-
-                prci = vk::PipelineRenderingCreateInfo{
-                    0,
-                    color_attachment_formats,
-                    ImageUtils::GetVkFormat(prop.attachments.depth),
-                    vk::Format::eUndefined
-                };
+            for (const auto & f : pri.color_attachment_format) {
+                if (f == ImageUtils::ImageFormat::UNDEFINED)    break;
+                color_attachment_formats.push_back(ImageUtils::GetVkFormat(f));
             }
+            assert(
+                color_attachment_formats.size() == prop.attachments.color_blending.size()
+                && "Mismatched color attachment and blending operation size."
+            );
+
+            prci = vk::PipelineRenderingCreateInfo{
+                0,
+                color_attachment_formats,
+                ImageUtils::GetVkFormat(pri.depth_stencil_attachment_format),
+                // XXX: stencil attachment support
+                vk::Format::eUndefined
+            };
 
             cbsi.logicOpEnable = vk::False;
+            std::vector<vk::PipelineColorBlendAttachmentState> cbass{
+                PipelineUtils::ToVulkanColorBlendingOps(prop.attachments.color_blending)
+            };
             cbsi.setAttachments(cbass);
 
             vk::GraphicsPipelineCreateInfo gpci{};

--- a/engine/Render/Pipeline/Material/MaterialTemplate.cpp
+++ b/engine/Render/Pipeline/Material/MaterialTemplate.cpp
@@ -7,6 +7,7 @@
 #include "Render/AttachmentUtilsFunc.h"
 #include "Render/DebugUtils.h"
 #include "Render/ImageUtilsFunc.h"
+#include "Render/Pipeline/PipelineRuntimeInfo.h"
 #include "Render/Pipeline/PipelineInfo.h"
 #include "Render/Pipeline/PipelineUtils.hpp"
 #include "Render/RenderSystem.h"
@@ -38,7 +39,7 @@ namespace Engine {
             RenderSystem & system,
             const std::vector <vk::ShaderModule> shader_modules,
             const MaterialTemplateSinglePassProperties &prop,
-            VertexAttribute attribute
+            const PipelineRuntimeInfo &pri
         ) {
             vk::Device device = system.GetDevice();
 
@@ -70,8 +71,8 @@ namespace Engine {
             bool use_swapchain_attachments =
                 prop.attachments.color.empty() && prop.attachments.depth == ImageUtils::ImageFormat::UNDEFINED;
 
-            auto vertex_bindings = attribute.ToVkVertexInputBinding();
-            auto vertex_attribute = attribute.ToVkVertexAttribute();
+            auto vertex_bindings = pri.va.ToVkVertexInputBinding();
+            auto vertex_attribute = pri.va.ToVkVertexAttribute();
             auto vis = vk::PipelineVertexInputStateCreateInfo{
                 vk::PipelineVertexInputStateCreateFlags{},
                 vertex_bindings,
@@ -176,11 +177,10 @@ namespace Engine {
         const std::vector<vk::ShaderModule> &shaders,
         vk::PipelineLayout layout,
         vk::DescriptorPool pool,
-        const ShdrRfl::SPLayout * reflected,
-        VertexAttribute attribute,
+        const ShdrRfl::SPLayout &reflected,
+        const PipelineRuntimeInfo &pri,
         const std::string &name
     ) : MaterialTemplate(system) {
-
         pimpl->m_name = name;
         SDL_LogInfo(SDL_LOG_CATEGORY_RENDER, "Creating pipelines for material %s.", pimpl->m_name.c_str());
         if (!pimpl->desc_pool) {
@@ -190,10 +190,10 @@ namespace Engine {
         pimpl->desc_pool = pool;
         
         pimpl->pipeline_layout = layout;
-        pimpl->m_layout = reflected;
+        pimpl->m_layout = &reflected;
 
         // Create pipelines
-        pimpl->CreatePipeline(system, shaders, properties, attribute);
+        pimpl->CreatePipeline(system, shaders, properties, pri);
     }
 
     MaterialTemplate::~MaterialTemplate() = default;

--- a/engine/Render/Pipeline/Material/MaterialTemplate.cpp
+++ b/engine/Render/Pipeline/Material/MaterialTemplate.cpp
@@ -91,10 +91,6 @@ namespace Engine {
                 if (f == ImageUtils::ImageFormat::UNDEFINED)    break;
                 color_attachment_formats.push_back(ImageUtils::GetVkFormat(f));
             }
-            assert(
-                color_attachment_formats.size() == prop.attachments.color_blending.size()
-                && "Mismatched color attachment and blending operation size."
-            );
 
             std::vector<vk::PipelineColorBlendAttachmentState> cbass{
                 PipelineUtils::ToVulkanColorBlendingOps(prop.attachments.color_blending)

--- a/engine/Render/Pipeline/Material/MaterialTemplate.h
+++ b/engine/Render/Pipeline/Material/MaterialTemplate.h
@@ -22,8 +22,7 @@ namespace Engine {
     class MaterialTemplateAsset;
     class MaterialTemplateProperties;
     class MaterialTemplateSinglePassProperties;
-
-    enum class MeshVertexType;
+    class PipelineRuntimeInfo;
 
     namespace PipelineInfo {
         class MaterialPassInfo;
@@ -64,8 +63,8 @@ namespace Engine {
             const std::vector <vk::ShaderModule> & shaders,
             vk::PipelineLayout layout,
             vk::DescriptorPool pool,
-            const ShdrRfl::SPLayout * reflected,
-            VertexAttribute attribute,
+            const ShdrRfl::SPLayout & reflected,
+            const PipelineRuntimeInfo & attribute,
             const std::string & name = ""
         );
 

--- a/engine/Render/Pipeline/PipelineRuntimeInfo.h
+++ b/engine/Render/Pipeline/PipelineRuntimeInfo.h
@@ -1,0 +1,96 @@
+#ifndef RENDER_PIPELINE_PIPELINERUNTIMEINFO_INCLUDED
+#define RENDER_PIPELINE_PIPELINERUNTIMEINFO_INCLUDED
+
+#include "Render/Renderer/VertexAttribute.h"
+#include "Render/ImageUtils.h"
+
+namespace Engine {
+    
+    /**
+     * @brief Runtime information for graphics pipelines that is determined on
+     * per draw basis.
+     * 
+     * Mainly includes mesh vertex attributes.
+     */
+    struct PipelineRuntimeInfoPerDraw {
+        VertexAttribute va;
+
+        bool operator== (const PipelineRuntimeInfoPerDraw &) const noexcept = default;
+    };
+
+    struct PipelineRuntimeInfoPerRenderingHeader {
+        /**
+         * How many samples are used for multisampling?
+         * 0 and 1 are equivalent and always accepted.
+         * Values that are not a power of two are not valid.
+         * Other values (e.g. 8) may be supported depending on the platform.
+         */
+        uint8_t samples : 8;
+        
+        /**
+         * Enable alpha-to-coverage technique for multisampling.
+         */
+        bool alpha_to_coverage_enable : 1;
+
+        /**
+         * Write one to alpha channel after multisampling.
+         * It should be combined with alpha-to-coverage technique.
+         */
+        bool alpha_to_one_enable : 1;
+
+        // Pad to 4 bytes
+        uint8_t : 0;
+        uint8_t _padding_1[2];
+
+        bool operator== (const PipelineRuntimeInfoPerRenderingHeader & rhs) const noexcept {
+            return (
+                samples == rhs.samples &&
+                alpha_to_coverage_enable == rhs.alpha_to_coverage_enable &&
+                alpha_to_one_enable == rhs.alpha_to_one_enable
+            );
+        };
+    };
+
+    /**
+     * @brief Runtime information for graphics pipelines that is determined on
+     * per rendering pass basis.
+     * 
+     * Mainly includes attachment information and multisample counts.
+     */
+    struct PipelineRuntimeInfoPerRendering : PipelineRuntimeInfoPerRenderingHeader {
+        /**
+         * 
+         * Color attachment format, terminated by UNDEFINED.
+         */
+        ImageUtils::ImageFormat color_attachment_format[8];
+        /**
+         * Depth and stencil attachment format.
+         */
+        ImageUtils::ImageFormat depth_stencil_attachment_format;
+
+        bool operator== (const PipelineRuntimeInfoPerRendering & rhs) const noexcept {
+            auto ret = static_cast<const PipelineRuntimeInfoPerRenderingHeader *>(this)->operator==(rhs);
+            if (ret == false)   return false;
+            if (depth_stencil_attachment_format != rhs.depth_stencil_attachment_format)
+                return false;
+
+            for (int i = 0; i < 8; i++) {
+                if (color_attachment_format[i] != rhs.color_attachment_format[i])
+                    return false;
+                // Both undefined -> terminated.
+                if (color_attachment_format[i] == ImageUtils::ImageFormat::UNDEFINED)
+                    return true;
+            }
+            return true;
+        };
+    };
+
+    /**
+     * @brief Runtime information necessary to build a graphics pipeline.
+     */
+    struct PipelineRuntimeInfo : PipelineRuntimeInfoPerDraw, PipelineRuntimeInfoPerRendering {
+        bool operator== (const PipelineRuntimeInfo &) const noexcept = default;
+    };
+}
+
+#endif // RENDER_PIPELINE_PIPELINERUNTIMEINFO_INCLUDED

--- a/engine/Render/Pipeline/PipelineRuntimeInfo.h
+++ b/engine/Render/Pipeline/PipelineRuntimeInfo.h
@@ -25,31 +25,18 @@ namespace Engine {
          * Values that are not a power of two are not valid.
          * Other values (e.g. 8) may be supported depending on the platform.
          */
-        uint8_t samples : 8;
-        
-        /**
-         * Enable alpha-to-coverage technique for multisampling.
-         */
-        bool alpha_to_coverage_enable : 1;
-
-        /**
-         * Write one to alpha channel after multisampling.
-         * It should be combined with alpha-to-coverage technique.
-         */
-        bool alpha_to_one_enable : 1;
+        uint8_t samples;
 
         // Pad to 4 bytes
-        uint8_t : 0;
-        uint8_t _padding_1[2];
+        uint8_t _padding[3];
 
         bool operator== (const PipelineRuntimeInfoPerRenderingHeader & rhs) const noexcept {
             return (
-                samples == rhs.samples &&
-                alpha_to_coverage_enable == rhs.alpha_to_coverage_enable &&
-                alpha_to_one_enable == rhs.alpha_to_one_enable
+                samples == rhs.samples
             );
         };
     };
+    static_assert(sizeof(PipelineRuntimeInfoPerRenderingHeader) == sizeof(uint32_t));
 
     /**
      * @brief Runtime information for graphics pipelines that is determined on

--- a/engine/Render/Pipeline/PipelineRuntimeInfo.h
+++ b/engine/Render/Pipeline/PipelineRuntimeInfo.h
@@ -91,6 +91,10 @@ namespace Engine {
     struct PipelineRuntimeInfo : PipelineRuntimeInfoPerDraw, PipelineRuntimeInfoPerRendering {
         bool operator== (const PipelineRuntimeInfo &) const noexcept = default;
     };
+    static_assert(
+        std::is_aggregate_v<PipelineRuntimeInfo>,
+        "PipelineRuntimeInfo is not an aggregate."
+    );
 }
 
 #endif // RENDER_PIPELINE_PIPELINERUNTIMEINFO_INCLUDED

--- a/engine/Render/Pipeline/PipelineUtils.hpp
+++ b/engine/Render/Pipeline/PipelineUtils.hpp
@@ -5,6 +5,7 @@
 
 #include "Asset/Material/PipelineProperty.h"
 #include "Render/Pipeline/PipelineEnums.h"
+#include "Render/Hasher.hpp"
 
 namespace Engine::PipelineUtils {
     constexpr vk::PolygonMode ToVkPolygonMode(FillingMode mode) {
@@ -18,6 +19,7 @@ namespace Engine::PipelineUtils {
         }
         __builtin_unreachable();
     }
+
     constexpr vk::CullModeFlags ToVkCullMode(CullingMode mode) {
         switch (mode) {
         case CullingMode::None:
@@ -31,6 +33,7 @@ namespace Engine::PipelineUtils {
         }
         __builtin_unreachable();
     }
+
     constexpr vk::FrontFace ToVkFrontFace(FrontFace face) {
         switch (face) {
         case FrontFace::Counterclockwise:
@@ -40,12 +43,15 @@ namespace Engine::PipelineUtils {
         }
         __builtin_unreachable();
     }
+
     constexpr vk::CompareOp ToVkCompareOp(DSComparator comp) {
         return static_cast<vk::CompareOp>(static_cast<int>(comp));
     }
+
     constexpr vk::StencilOp ToVkStencilOp(StencilOperation op) {
         return static_cast<vk::StencilOp>(static_cast<int>(op));
     }
+
     constexpr vk::BlendOp ToVkBlendOp(BlendOperation op) {
         switch (op) {
         case BlendOperation::None:
@@ -90,6 +96,29 @@ namespace Engine::PipelineUtils {
         }
         __builtin_unreachable();
     }
+    
+    /**
+     * @brief Hasher for `PipelineRuntimeInfo` struct.
+     */
+    struct pipeline_runtime_info_hasher {
+        size_t operator() (const Engine::PipelineRuntimeInfo & pri) const noexcept {
+            Engine::RenderResourceHasher h;
+
+            h.u64(pri.va.packed);
+            
+            const auto & upcasted = static_cast<const Engine::PipelineRuntimeInfoPerRenderingHeader &>(pri);
+            h.any(upcasted);
+
+            h.u32(static_cast<uint32_t>(pri.depth_stencil_attachment_format));
+            for (int i = 0; i < 8; i++) {
+                if (pri.color_attachment_format[i] == Engine::ImageUtils::ImageFormat::UNDEFINED)
+                    break;
+                h.u32(static_cast<uint32_t>(pri.color_attachment_format[i]));
+            }
+
+            return h.get();
+        }
+    };
 
     /**
      * Converts a ShaderAsset::ShaderType to a Vulkan shader stage flag bits.

--- a/engine/Render/Pipeline/RenderGraph/RenderGraphBuilder.cpp
+++ b/engine/Render/Pipeline/RenderGraph/RenderGraphBuilder.cpp
@@ -245,8 +245,17 @@ namespace Engine {
     ) {
         std::function<void(vk::CommandBuffer, const RenderGraph &)> f = [system = &this->m_system,
                                                     pass,
+                                                    color_rt = color.rt_handle,
                                                     name](vk::CommandBuffer cb, const RenderGraph & rg) {
             GraphicsCommandBuffer gcb{*system, cb, system->GetFrameManager().GetFrameInFlight()};
+            gcb.SetRenderingInfo({
+                {},
+                {
+                    rg.GetInternalTextureResource(color_rt)->GetTextureDescription().format,
+                    ImageUtils::ImageFormat::UNDEFINED
+                },
+                ImageUtils::ImageFormat::UNDEFINED
+            });
             std::invoke(pass, std::ref(gcb), std::cref(rg));
         };
 
@@ -267,8 +276,18 @@ namespace Engine {
     ) {
         std::function<void(vk::CommandBuffer, const RenderGraph &)> f = [system = &this->m_system,
                                                     pass,
+                                                    color_rt = color.rt_handle,
+                                                    depth_rt = depth.rt_handle,
                                                     name](vk::CommandBuffer cb, const RenderGraph & rg) {
             GraphicsCommandBuffer gcb{*system, cb, system->GetFrameManager().GetFrameInFlight()};
+            gcb.SetRenderingInfo({
+                {},
+                {
+                    rg.GetInternalTextureResource(color_rt)->GetTextureDescription().format,
+                    ImageUtils::ImageFormat::UNDEFINED
+                },
+                rg.GetInternalTextureResource(depth_rt)->GetTextureDescription().format
+            });
             std::invoke(pass, std::ref(gcb), std::cref(rg));
         };
 
@@ -288,11 +307,29 @@ namespace Engine {
         std::function<void(GraphicsCommandBuffer &, const RenderGraph &)> pass,
         const std::string &name
     ) {
+        assert(colors.size() <= 8 && "Too many color attachments.");
+        std::vector <uint32_t> color_rts;
+        std::transform(
+            colors.begin(),
+            colors.end(),
+            std::back_inserter(color_rts),
+            [] (const RGAttachmentDesc & rgad) {
+                return rgad.rt_handle;
+            }
+        );
+
         std::function<void(vk::CommandBuffer, const RenderGraph &)> f = [system = &this->m_system,
                                                     pass,
+                                                    color_rts = std::move(color_rts),
+                                                    depth_rt = depth.rt_handle,
                                                     name](vk::CommandBuffer cb, const RenderGraph & rg) {
 
             GraphicsCommandBuffer gcb{*system, cb, system->GetFrameManager().GetFrameInFlight()};
+            PipelineRuntimeInfoPerRendering pripr{};
+            for (int i = 0; i < color_rts.size(); i++) {
+                pripr.color_attachment_format[i] = rg.GetInternalTextureResource(color_rts[i])->GetTextureDescription().format;
+            }
+            pripr.depth_stencil_attachment_format = rg.GetInternalTextureResource(depth_rt)->GetTextureDescription().format;
             std::invoke(pass, std::ref(gcb), std::cref(rg));
         };
         pimpl->m_tasks.push_back(

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraph2.cpp
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraph2.cpp
@@ -8,6 +8,8 @@ namespace Engine {
         std::vector <RenderGraphCompiledPass> passes{};
         RenderGraph2ExtraInfo extra_info{};
 
+        const PipelineRuntimeInfoPerRendering * pripr_ptr{nullptr};
+
         std::vector <
             std::tuple<
                 const RenderTargetTexture *,
@@ -96,6 +98,12 @@ namespace Engine {
         return nullptr;
     }
 
+    const PipelineRuntimeInfoPerRendering &
+    RenderGraph2::GetCurrentPassRuntimeInfo() const noexcept {
+        assert(pimpl->pripr_ptr);
+        return *pimpl->pripr_ptr;
+    }
+
     void RenderGraph2::Record(
         uint32_t pass,
         vk::CommandBuffer cb
@@ -126,7 +134,9 @@ namespace Engine {
                 bmb, {}, imb
             });
             // Invoke pass function.
+            pimpl->pripr_ptr = &subpass.per_rendering_info;
             std::invoke(subpass.pass_work, cb, *this);
+            pimpl->pripr_ptr = nullptr;
         }
     }
 

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraph2.h
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraph2.h
@@ -9,6 +9,7 @@ namespace Engine {
 
     class RenderGraphCompiledPass;
     class RenderGraph2ExtraInfo;
+    class PipelineRuntimeInfoPerRendering;
 
     enum class RGTextureHandle : int32_t;
     enum class RGBufferHandle : int32_t;
@@ -58,6 +59,13 @@ namespace Engine {
         RenderTargetTexture * GetInternalTextureResource(
             RGTextureHandle handle
         ) const noexcept;
+
+        /**
+         * @brief Request the graphics pipeline runtime information of the
+         * current pass or subpass.
+         */
+        const PipelineRuntimeInfoPerRendering &
+        GetCurrentPassRuntimeInfo() const noexcept;
 
         /**
          * @brief Record all operations of a given pass onto the specified

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraphBuilder2.cpp
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraphBuilder2.cpp
@@ -227,6 +227,47 @@ namespace Engine {
             }
             return dg;
         }
+
+        /**
+         * @brief Build pipeline rendering info for a subpass
+         */
+        PipelineRuntimeInfoPerRendering GetPerRenderingInfo (
+            const RenderGraphPass & subpass
+        ) const noexcept {
+            PipelineRuntimeInfoPerRendering ret{};
+
+            std::fill(
+                ret.color_attachment_format,
+                ret.color_attachment_format + 8,
+                ImageUtils::ImageFormat::UNDEFINED
+            );
+            uint8_t multisample_count{0};
+            for (int i = 0; i < subpass.color_attachments.size(); i++) {
+                ImageUtils::ImageFormat format;
+                auto rth = subpass.color_attachments[i].rt_handle;
+                // Imported external resource
+                if (static_cast<int32_t>(rth) < 0) {
+                    format = rs.texture_mapping.at(rth)->GetTextureDescription().format;
+                } else {
+                    format = static_cast<ImageUtils::ImageFormat>(
+                        rs.texture_creation_info.at(rth).t.format
+                    );
+                }
+                ret.color_attachment_format[i] = format;
+            }
+            auto drth = subpass.depth_attachment.rt_handle;
+            if (static_cast<int32_t>(drth) < 0) {
+                ret.depth_stencil_attachment_format = rs.texture_mapping.at(drth)->GetTextureDescription().format;
+            } else if (static_cast<int32_t>(drth) > 0) {
+                ret.depth_stencil_attachment_format = static_cast<ImageUtils::ImageFormat>(
+                    rs.texture_creation_info.at(drth).t.format
+                );
+            } else {
+                ret.depth_stencil_attachment_format = ImageUtils::ImageFormat::UNDEFINED;
+            }
+
+            return ret;
+        }
     };
 
     RenderGraphBuilder2::RenderGraphBuilder2(
@@ -540,6 +581,9 @@ namespace Engine {
                         )
                     );
                 }
+
+                // Prepare attachment information
+                subpass.per_rendering_info = pimpl->GetPerRenderingInfo(old_p);
                 p[i].subpasses.push_back(std::move(subpass));
             }
         }

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.cpp
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.cpp
@@ -11,6 +11,7 @@ namespace Engine {
         auto f = [system = &this->system,
                 fn](vk::CommandBuffer cb, const RenderGraph2 & rg) {
             GraphicsCommandBuffer gcb{*system, cb, system->GetFrameManager().GetFrameInFlight()};
+            gcb.SetRenderingInfo(rg.GetCurrentPassRuntimeInfo());
             std::invoke(fn, std::ref(gcb), std::cref(rg));
         };
         pass.pass_function = f;

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.cpp
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.cpp
@@ -27,7 +27,7 @@ namespace Engine {
                 fn](vk::CommandBuffer cb, const RenderGraph2 & rg) {
 
             ComputeCommandBuffer ccb{cb, system->GetFrameManager().GetFrameInFlight()};
-            DEBUG_CMD_START_LABEL(cb, std::format("Compute Pass {}", name).c_str());
+            DEBUG_CMD_START_LABEL(cb, std::format("{} (Compute)", name).c_str());
             std::invoke(fn, std::ref(ccb), std::cref(rg));
             DEBUG_CMD_END_LABEL(cb);
         };
@@ -57,7 +57,7 @@ namespace Engine {
             vk::RenderingAttachmentInfo dai{}, sai{};
 
             // Fill up color attachment info.
-            for (size_t i = 0; i < cai.size(); i++) {
+            for (size_t i = 0; i < ca.size(); i++) {
                 auto t = rg.GetInternalTextureResource(ca[i].rt_handle);
                 cai[i] = vk::RenderingAttachmentInfo{
                     t->GetImageView(ca[i].range),
@@ -102,7 +102,7 @@ namespace Engine {
                 sai = {nullptr};
             }
 
-            DEBUG_CMD_START_LABEL(cb, std::format("Rasterizer Pass {}", name).c_str());
+            DEBUG_CMD_START_LABEL(cb, std::format("{} (Rasterizer)", name).c_str());
             cb.beginRendering(vk::RenderingInfo{
                 vk::RenderingFlags{},
                 rendering_area,

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraphStruct.hpp
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraphStruct.hpp
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.hpp>
 
 #include "Render/Memory/MemoryAccessTypes.h"
+#include "Render/Pipeline/PipelineRuntimeInfo.h"
 
 namespace Engine {
     class RenderGraph2;
@@ -24,6 +25,8 @@ namespace Engine {
             std::vector <std::pair<RGTextureHandle, vk::ImageMemoryBarrier2>> image_barriers {};
             std::vector <std::pair<RGBufferHandle, vk::BufferMemoryBarrier2>> buffer_barriers {};
             vk::MemoryBarrier2 global_memory_barrier {};
+
+            PipelineRuntimeInfoPerRendering per_rendering_info {};
 
             std::function <void(vk::CommandBuffer, const RenderGraph2 & rg)> pass_work {};
         };

--- a/engine/Render/RenderSystem/SceneDataManager.cpp
+++ b/engine/Render/RenderSystem/SceneDataManager.cpp
@@ -337,11 +337,6 @@ namespace Engine::RenderSystemState {
             }
         );
 
-        if (pimpl->skybox.skybox_material) {
-            auto tpl = pimpl->skybox.skybox_material->GetLibrary().FindMaterialTemplate("SKYBOX", {0});
-            pimpl->skybox.skybox_material->UpdateGPUInfo(*tpl, frame_in_flight);
-        }
-
         if (!descriptor_writes.empty()) {
             pimpl->device.updateDescriptorSets(
                 {descriptor_writes},
@@ -357,25 +352,29 @@ namespace Engine::RenderSystemState {
     }
 
     void SceneDataManager::DrawSkybox(
-        vk::CommandBuffer cb, uint32_t frame_in_flight, glm::mat3 view_mat, glm::mat4 proj_mat
+        GraphicsCommandBuffer & cb,
+        uint32_t frame_in_flight,
+        glm::mat3 view_mat,
+        glm::mat4 proj_mat
     ) const {
         if (!pimpl->skybox.skybox_material)  return;
 
         vk::Extent2D extent = m_system.GetSwapchain().GetExtent();
         vk::Rect2D scissor{{0, 0}, extent};
-        vk::Viewport vp;
-        vp.setWidth(extent.width).setHeight(extent.height);
-        vp.setX(0.0f).setY(0.0f);
-        vp.setMaxDepth(1.0f).setMinDepth(0.0f);
-        cb.setViewport(0, 1, &vp);
-        cb.setScissor(0, 1, &scissor);
+        cb.SetupViewport(extent.width, extent.height, scissor);
 
         glm::mat4 pv = proj_mat * glm::mat4(view_mat);
 
-        auto tpl = pimpl->skybox.skybox_material->GetLibrary().FindMaterialTemplate("SKYBOX", {0});
-        cb.bindPipeline(vk::PipelineBindPoint::eGraphics, tpl->GetPipeline());
+        auto tpl = pimpl->skybox.skybox_material->GetLibrary().FindMaterialTemplate(
+            "SKYBOX",
+            {{0}, cb.GetRenderingInfo()}
+        );
+        pimpl->skybox.skybox_material->UpdateGPUInfo(*tpl, frame_in_flight);
+
+        auto rcb = cb.GetCommandBuffer();
+        rcb.bindPipeline(vk::PipelineBindPoint::eGraphics, tpl->GetPipeline());
         const auto &sky_box_descriptor_set = pimpl->skybox.skybox_material->GetDescriptor(*tpl, frame_in_flight);
-        cb.bindDescriptorSets(
+        rcb.bindDescriptorSets(
             vk::PipelineBindPoint::eGraphics,
             tpl->GetPipelineLayout(),
             2,
@@ -383,7 +382,7 @@ namespace Engine::RenderSystemState {
             {}
         );
         // camera PV matrix is pushed directly.
-        cb.pushConstants(
+        rcb.pushConstants(
             tpl->GetPipelineLayout(),
             vk::ShaderStageFlagBits::eAllGraphics,
             0,
@@ -391,7 +390,7 @@ namespace Engine::RenderSystemState {
             { reinterpret_cast<const void *>(&pv) }
         );
         // Vertex info is embedded in the skybox.vert shader.
-        cb.draw(36, 1, 0, 0);
+        rcb.draw(36, 1, 0, 0);
     }
 
     vk::DescriptorSet SceneDataManager::GetLightDescriptorSet(uint32_t frame_in_flight) const noexcept {

--- a/engine/Render/RenderSystem/SceneDataManager.h
+++ b/engine/Render/RenderSystem/SceneDataManager.h
@@ -5,7 +5,6 @@
 #include <fwd.hpp>
 
 namespace vk {
-    class CommandBuffer;
     class DescriptorSet;
     class DescriptorSetLayout;
 }
@@ -13,6 +12,8 @@ namespace vk {
 namespace Engine {
     class RenderSystem;
     class MaterialInstance;
+    class GraphicsCommandBuffer;
+
     namespace RenderSystemState {
         /**
          * @brief Aggregated manager for scene data, such as lights and skybox.
@@ -115,6 +116,11 @@ namespace Engine {
 
             /**
              * @brief Record commands for drawing a skybox.
+             * 
+             * This method should be called with in a render pass. You can use
+             * `GraphicsCommandBuffer::BeginRendering()` or render graph to do
+             * this.
+             * 
              * @param cb The command buffer to record commands into.
              * @param frame_in_flight The current frame in flight index.
              * @param view_mat The view matrix of the current camera. 3x3 matrix (no translation).
@@ -122,7 +128,12 @@ namespace Engine {
              * 
              * @todo It should be relocated and integrated with GraphicsCommandBuffer.
              */
-            void DrawSkybox(vk::CommandBuffer cb, uint32_t frame_in_flight, glm::mat3 view_mat, glm::mat4 proj_mat) const;
+            void DrawSkybox(
+                GraphicsCommandBuffer & cb,
+                uint32_t frame_in_flight,
+                glm::mat3 view_mat,
+                glm::mat4 proj_mat
+            ) const;
 
             vk::DescriptorSet GetLightDescriptorSet(uint32_t frame_in_flight) const noexcept;
             vk::DescriptorSetLayout GetLightDescriptorSetLayout() const noexcept;

--- a/engine/Render/Renderer/VertexAttribute.h
+++ b/engine/Render/Renderer/VertexAttribute.h
@@ -71,6 +71,10 @@ namespace Engine {
     struct VertexAttribute {
         uint64_t packed;
 
+        bool operator == (const VertexAttribute & rhs) const noexcept {
+            return packed == rhs.packed;
+        }
+
         VertexAttribute & SetAttribute(VertexAttributeSemantic semantic, VertexAttributeType type) noexcept {
             uint64_t type_bits {static_cast<uint8_t>(type)};
             uint64_t mask {0xF};

--- a/test/mrt_test.cpp
+++ b/test/mrt_test.cpp
@@ -134,18 +134,26 @@ RenderGraph BuildRenderGraph(
             gcb.SetupViewport(extent.width, extent.height, {{0, 0}, extent});
             gcb.BindSceneResources(rsys->GetSceneDataManager());
             gcb.BindCameraResources(rsys->GetCameraManager());
-            VertexAttribute attribute;
-            attribute.SetAttribute(VertexAttributeSemantic::Position, VertexAttributeType::SFloat32x3);
-            attribute.SetAttribute(VertexAttributeSemantic::Color, VertexAttributeType::SFloat32x3);
-            attribute.SetAttribute(VertexAttributeSemantic::Normal, VertexAttributeType::SFloat32x3);
-            attribute.SetAttribute(VertexAttributeSemantic::Texcoord0, VertexAttributeType::SFloat32x2);
-            auto tpl = material->GetLibrary().FindMaterialTemplate("", attribute);
+
+            PipelineRuntimeInfo pri{};
+            pri.va.SetAttribute(VertexAttributeSemantic::Position, VertexAttributeType::SFloat32x3);
+            pri.va.SetAttribute(VertexAttributeSemantic::Color, VertexAttributeType::SFloat32x3);
+            pri.va.SetAttribute(VertexAttributeSemantic::Normal, VertexAttributeType::SFloat32x3);
+            pri.va.SetAttribute(VertexAttributeSemantic::Texcoord0, VertexAttributeType::SFloat32x2);
+            pri.color_attachment_format[0] = color_1->GetTextureDescription().format;
+            pri.color_attachment_format[1] = color_2->GetTextureDescription().format;
+            pri.color_attachment_format[2] = color_3->GetTextureDescription().format;
+            pri.color_attachment_format[3] = color_4->GetTextureDescription().format;
+            pri.color_attachment_format[4] = ImageUtils::ImageFormat::UNDEFINED;
+            pri.depth_stencil_attachment_format = depth->GetTextureDescription().format;
+
+            auto tpl = material->GetLibrary().FindMaterialTemplate("", pri);
             assert(tpl);
             gcb.BindMaterial(*material, *tpl);
             // Push model matrix...
             vk::CommandBuffer rcb = gcb.GetCommandBuffer();
             rcb.pushConstants(
-                material->GetLibrary().FindMaterialTemplate("", attribute)->GetPipelineLayout(),
+                material->GetLibrary().FindMaterialTemplate("", pri)->GetPipelineLayout(),
                 vk::ShaderStageFlagBits::eAllGraphics,
                 0,
                 sizeof(RenderSystemState::RendererManager::RendererDataStruct),

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -127,16 +127,22 @@ RenderGraph BuildRenderGraph(
             extent
         );
 
+        PipelineRuntimeInfo pri{};
+        pri.va = mesh->GetVertexAttributeFormat();
+        pri.color_attachment_format[0] = color->GetTextureDescription().format;
+        pri.color_attachment_format[1] = ImageUtils::ImageFormat::UNDEFINED;
+        pri.depth_stencil_attachment_format = depth->GetTextureDescription().format;
+
         gcb.SetupViewport(extent.width, extent.height, {{0, 0}, extent});
         gcb.BindSceneResources(rsys->GetSceneDataManager());
         gcb.BindCameraResources(rsys->GetCameraManager());
-        auto tpl = material->GetLibrary().FindMaterialTemplate("", mesh->GetVertexAttributeFormat());
+        auto tpl = material->GetLibrary().FindMaterialTemplate("", pri);
         assert(tpl);
         gcb.BindMaterial(*material, *tpl);
         // Push model matrix...
         vk::CommandBuffer rcb = gcb.GetCommandBuffer();
         rcb.pushConstants(
-            material->GetLibrary().FindMaterialTemplate("", mesh->GetVertexAttributeFormat())->GetPipelineLayout(),
+            material->GetLibrary().FindMaterialTemplate("", pri)->GetPipelineLayout(),
             vk::ShaderStageFlagBits::eAllGraphics,
             0,
             sizeof (RenderSystemState::RendererManager::RendererDataStruct),

--- a/test/skybox_test.cpp
+++ b/test/skybox_test.cpp
@@ -168,7 +168,7 @@ int main(int argc, char **argv) {
         {drt, {}, AttachmentUtils::LoadOperation::Clear, AttachmentUtils::StoreOperation::DontCare, AttachmentUtils::DepthClearValue{1.0f, 0U}},
             [rsys, camera] (GraphicsCommandBuffer & cb, const RenderGraph &) -> void {
                 rsys->GetSceneDataManager().DrawSkybox(
-                    cb.GetCommandBuffer(),
+                    cb,
                     rsys->GetFrameManager().GetFrameInFlight(),
                     camera->GetViewMatrix(),
                     camera->GetProjectionMatrix()


### PR DESCRIPTION
This PR introduces a more flexible graphics pipeline scheme. Now attachment formats and multisample states can be specified by runtime instead of in the asset. `ImageUtils::ImageFormat`s in `PipelineProperties::Attachments` are therefore no longer needed.

This opens up possibilities for other functionalities unsuitable to be serialized in the asset, such as multisample states or filling mode.

This PR does not affect public high level interfaces. Only lower level interfaces such as `FindMaterialTemplate()` are affected.