### PR TITLE
Ad hoc improvements on Synchronization API

### DIFF
--- a/engine/Render/Memory/Texture.cpp
+++ b/engine/Render/Memory/Texture.cpp
@@ -227,8 +227,8 @@ namespace Engine {
     }
 
     size_t Texture::CalculateStagingBufferSizeNoMipmap() const noexcept {
-        return pimpl->m_tdesc.height * pimpl->m_tdesc.width * pimpl->m_tdesc.depth
-                * pimpl->m_tdesc.array_layers * ImageUtils::GetPixelSize(pimpl->m_tdesc.format);
+        return pimpl->m_tdesc.height * pimpl->m_tdesc.width * pimpl->m_tdesc.depth * pimpl->m_tdesc.array_layers
+               * ImageUtils::GetPixelSize(pimpl->m_tdesc.format);
     }
 
     bool Texture::SupportRandomAccess() const noexcept {

--- a/engine/Render/Memory/Texture.cpp
+++ b/engine/Render/Memory/Texture.cpp
@@ -226,20 +226,11 @@ namespace Engine {
         return pimpl->m_sampler;
     }
 
-    std::unique_ptr<DeviceBuffer> Engine::Texture::CreateStagingBuffer(
-        const RenderSystemState::AllocatorState &allocator
-    ) const {
-        uint64_t buffer_size = pimpl->m_tdesc.height * pimpl->m_tdesc.width * pimpl->m_tdesc.depth
-                               * pimpl->m_tdesc.array_layers * ImageUtils::GetPixelSize(pimpl->m_tdesc.format);
-        assert(buffer_size > 0);
-
-        return DeviceBuffer::CreateUnique(
-            allocator,
-            {BufferTypeBits::StagingToDevice},
-            buffer_size,
-            std::format("Buffer - texture ({}) staging", pimpl->m_name)
-        );
+    size_t Texture::CalculateStagingBufferSizeNoMipmap() const noexcept {
+        return pimpl->m_tdesc.height * pimpl->m_tdesc.width * pimpl->m_tdesc.depth
+                * pimpl->m_tdesc.array_layers * ImageUtils::GetPixelSize(pimpl->m_tdesc.format);
     }
+
     bool Texture::SupportRandomAccess() const noexcept {
         return false;
     }

--- a/engine/Render/Memory/Texture.h
+++ b/engine/Render/Memory/Texture.h
@@ -81,9 +81,13 @@ namespace Engine {
         vk::ImageView GetImageView(const TextureSubresourceRange &tsr) const;
 
         /**
-         * @brief Acquire a buffer large enough to hold the whole texture.
+         * @brief Calculate the size of staging buffer required to hold the
+         * entire texture.
+         * 
+         * It does not consider mipmap levels of the texture. Only the first
+         * level is considered.
          */
-        std::unique_ptr<DeviceBuffer> CreateStagingBuffer(const RenderSystemState::AllocatorState &allocator) const;
+        size_t CalculateStagingBufferSizeNoMipmap() const noexcept;
 
         /**
          * @brief Whether this texture supports random access (UAV

--- a/engine/Render/Memory/Texture.h
+++ b/engine/Render/Memory/Texture.h
@@ -83,7 +83,7 @@ namespace Engine {
         /**
          * @brief Calculate the size of staging buffer required to hold the
          * entire texture.
-         * 
+         *
          * It does not consider mipmap levels of the texture. Only the first
          * level is considered.
          */

--- a/engine/Render/Pipeline/Material/MaterialInstance.cpp
+++ b/engine/Render/Pipeline/Material/MaterialInstance.cpp
@@ -260,8 +260,7 @@ namespace Engine {
                     );
                     AssignTexture(prop.first, texture);
                     m_system.GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-                        *texture, 
-                        std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}
+                        *texture, std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}
                     );
                 }
                 auto solid_color_asset = dynamic_cast<SolidColorTextureAsset *>(t_asset);
@@ -294,13 +293,12 @@ namespace Engine {
             }
             case MaterialProperty::Type::CubeTexture: {
                 auto texture_asset = std::any_cast<AssetRef>(p.m_value).as<ImageCubemapAsset>();
-                auto texture =
-                    std::shared_ptr<ImageTexture>(std::move(ImageTexture::CreateUnique(this->m_system, *texture_asset))
-                    );
+                auto texture = std::shared_ptr<ImageTexture>(
+                    std::move(ImageTexture::CreateUnique(this->m_system, *texture_asset))
+                );
                 AssignTexture(prop.first, texture);
                 m_system.GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-                    *texture, 
-                    std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}
+                    *texture, std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}
                 );
                 break;
             }

--- a/engine/Render/Pipeline/Material/MaterialInstance.cpp
+++ b/engine/Render/Pipeline/Material/MaterialInstance.cpp
@@ -293,9 +293,9 @@ namespace Engine {
             }
             case MaterialProperty::Type::CubeTexture: {
                 auto texture_asset = std::any_cast<AssetRef>(p.m_value).as<ImageCubemapAsset>();
-                auto texture = std::shared_ptr<ImageTexture>(
-                    std::move(ImageTexture::CreateUnique(this->m_system, *texture_asset))
-                );
+                auto texture =
+                    std::shared_ptr<ImageTexture>(std::move(ImageTexture::CreateUnique(this->m_system, *texture_asset))
+                    );
                 AssignTexture(prop.first, texture);
                 m_system.GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
                     *texture, std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}

--- a/engine/Render/Pipeline/Material/MaterialInstance.cpp
+++ b/engine/Render/Pipeline/Material/MaterialInstance.cpp
@@ -260,7 +260,8 @@ namespace Engine {
                     );
                     AssignTexture(prop.first, texture);
                     m_system.GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-                        *texture, texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()
+                        *texture, 
+                        std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}
                     );
                 }
                 auto solid_color_asset = dynamic_cast<SolidColorTextureAsset *>(t_asset);
@@ -298,7 +299,8 @@ namespace Engine {
                     );
                 AssignTexture(prop.first, texture);
                 m_system.GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-                    *texture, texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()
+                    *texture, 
+                    std::span{texture_asset->GetPixelData(), texture_asset->GetPixelDataSize()}
                 );
                 break;
             }

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.cpp
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.cpp
@@ -33,6 +33,22 @@ namespace Engine {
         pass.affinity = RenderGraphPassAffinity::Graphics;
         return *this;
     }
+
+    RenderGraphPassBuilder &RenderGraphPassBuilder::SetTransferPassFunction(
+        std::function<void(TransferCommandBuffer &, const RenderGraph2 &)> fn
+    ) noexcept {
+        auto f = [name = pass.name, system = &this->system, fn](vk::CommandBuffer cb, const RenderGraph2 &rg) {
+            TransferCommandBuffer ccb{cb};
+            DEBUG_CMD_START_LABEL(cb, std::format("{} (Compute)", name).c_str());
+            std::invoke(fn, std::ref(ccb), std::cref(rg));
+            DEBUG_CMD_END_LABEL(cb);
+        };
+        pass.pass_function = f;
+        pass.actual_type = RenderGraphPassAffinity::Transfer;
+        pass.affinity = RenderGraphPassAffinity::Graphics;
+        return *this;
+    }
+
     RenderGraphPassBuilder &RenderGraphPassBuilder::WrapRenderPass() noexcept {
         assert(pass.actual_type == RenderGraphPassAffinity::Graphics);
         assert(pass.color_attachments.size() > 0 || static_cast<int32_t>(pass.depth_attachment.rt_handle) != 0);

--- a/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.h
+++ b/engine/Render/Pipeline/RenderGraph2/RenderGraphPass.h
@@ -85,6 +85,17 @@ namespace Engine {
         ) noexcept;
 
         /**
+         * @brief Set up a pass function for transfer invocations.
+         *
+         * Actual type of the pass is set to Transfer.
+         * Affinity is set to Graphics. See `SetAffinity()` for more
+         * details.
+         */
+        RenderGraphPassBuilder &SetTransferPassFunction(
+            std::function<void(TransferCommandBuffer &, const RenderGraph2 &)> f
+        ) noexcept;
+
+        /**
          * @brief Set affinity of the pass.
          *
          * Affinity determines whether the workload will be redistributed to

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -512,47 +512,4 @@ namespace Engine::RenderSystemState {
     const FrameSemaphore &FrameManager::GetFrameSemaphore() const noexcept {
         return pimpl->timeline_semaphores[GetFrameInFlight()];
     }
-
-    std::shared_ptr<DeviceBuffer> FrameManager::EnqueuePostGraphicsBufferReadback(const DeviceBuffer &device_buffer) {
-        // This has to be a shared pointer as release time is undetermined.
-        std::shared_ptr staging_buffer = DeviceBuffer::CreateUnique(
-            pimpl->m_system.GetAllocatorState(), {BufferTypeBits::ReadbackFromDevice}, device_buffer.GetSize()
-        );
-
-        auto enqueued = [&device_buffer, staging_buffer](vk::CommandBuffer cb) -> void {
-            ReadbackCommand(cb, device_buffer, *staging_buffer);
-        };
-        pimpl->readback.post_graphics_commands.push(enqueued);
-
-        return staging_buffer;
-    }
-    std::shared_ptr<DeviceBuffer> FrameManager::EnqueuePostGraphicsImageReadback(
-        const Texture &image, uint32_t array_layer, uint32_t miplevel
-    ) {
-        auto texture_desc = image.GetTextureDescription();
-        assert(array_layer <= texture_desc.array_layers);
-        assert(miplevel <= texture_desc.mipmap_levels);
-        // This has to be a shared pointer as release time is undetermined.
-        std::shared_ptr staging_buffer = DeviceBuffer::CreateUnique(
-            pimpl->m_system.GetAllocatorState(),
-            {BufferTypeBits::ReadbackFromDevice},
-            texture_desc.width * texture_desc.height * texture_desc.depth
-                * ImageUtils::GetPixelSize(texture_desc.format)
-        );
-
-        auto enqueued = [=, &image](vk::CommandBuffer cb) -> void {
-            ReadbackCommand(
-                cb,
-                image,
-                vk::ImageAspectFlagBits::eColor,
-                miplevel,
-                array_layer,
-                vk::Extent3D{texture_desc.width, texture_desc.height, texture_desc.depth},
-                *staging_buffer
-            );
-        };
-        pimpl->readback.post_graphics_commands.push(enqueued);
-
-        return staging_buffer;
-    }
 } // namespace Engine::RenderSystemState

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -112,25 +112,23 @@ namespace Engine::RenderSystemState {
                 // TODO: reuse fences and command buffers to avoid frequent reallocation.
                 vk::UniqueFence fence;
                 vk::UniqueCommandBuffer combuf;
-                std::deque <
-                    std::pair<ReadbackCallback, std::unique_ptr<DeviceBuffer>>
-                > callbacks;
+                std::deque<std::pair<ReadbackCallback, std::unique_ptr<DeviceBuffer>>> callbacks;
             };
 
             ReadbackRegistry current_registry;
 
-            std::deque <ReadbackRegistry> registry;
+            std::deque<ReadbackRegistry> registry;
 
-            bool HasReadback() const { return static_cast<bool>(current_registry.fence); }
+            bool HasReadback() const {
+                return static_cast<bool>(current_registry.fence);
+            }
 
-            void InitializeRegistry(const RenderSystemState::DeviceInterface & di) {
+            void InitializeRegistry(const RenderSystemState::DeviceInterface &di) {
                 assert(!current_registry.fence && "Reinitializing readback registry");
                 current_registry.fence = di.GetDevice().createFenceUnique(vk::FenceCreateInfo{});
 
                 auto cbai = vk::CommandBufferAllocateInfo{
-                    di.GetQueueInfo().graphicsOneTimePool.get(),
-                    vk::CommandBufferLevel::ePrimary,
-                    1
+                    di.GetQueueInfo().graphicsOneTimePool.get(), vk::CommandBufferLevel::ePrimary, 1
                 };
                 auto onetime_cb = di.GetDevice().allocateCommandBuffersUnique(cbai);
                 current_registry.combuf = std::move(onetime_cb[0]);
@@ -211,9 +209,7 @@ namespace Engine::RenderSystemState {
         for (uint32_t i = 0; i < FRAMES_IN_FLIGHT; i++) {
             timeline_semaphores[i].SetSemaphore(device.createSemaphoreUnique(scinfo));
             DEBUG_SET_NAME_TEMPLATE(
-                device,
-                timeline_semaphores[i].GetSemaphore(),
-                std::format("Semaphore - timeline semaphore {}", i)
+                device, timeline_semaphores[i].GetSemaphore(), std::format("Semaphore - timeline semaphore {}", i)
             );
         }
 
@@ -300,9 +296,7 @@ namespace Engine::RenderSystemState {
         // Kickstart of this frame
         // Prevent validation layer from complaining
         if (pimpl->timeline_semaphores[fif].GetTotalElapsedTimepoints() > 0) {
-            device.signalSemaphore(
-                pimpl->timeline_semaphores[fif].GetSignalInfo(1)
-            );
+            device.signalSemaphore(pimpl->timeline_semaphores[fif].GetSignalInfo(1));
         }
 
         // Acquire new image
@@ -345,8 +339,7 @@ namespace Engine::RenderSystemState {
             vk::PipelineStageFlagBits2::eAllCommands
         );
         wait_infos[1] = prev_timeline_semaphore.GetSubmitInfo(
-            prev_timeline_semaphore.GetExpectedTimepoints(),
-            vk::PipelineStageFlagBits2::eAllCommands
+            prev_timeline_semaphore.GetExpectedTimepoints(), vk::PipelineStageFlagBits2::eAllCommands
         );
         // special consideration for deadlock on the first frame.
         if (GetTotalFrame() == 0) {
@@ -465,15 +458,7 @@ namespace Engine::RenderSystemState {
 
             const auto &gqueue = m_system.GetDeviceInterface().GetQueueInfo().graphicsQueue;
             gqueue.submit2(
-                {
-                    vk::SubmitInfo2{
-                        vk::SubmitFlags{},
-                        wait_infos,
-                        {cbsi},
-                        {}
-                    }
-                },
-                readback.current_registry.fence.get()
+                {vk::SubmitInfo2{vk::SubmitFlags{}, wait_infos, {cbsi}, {}}}, readback.current_registry.fence.get()
             );
 
             readback.AddRegistery();
@@ -481,14 +466,14 @@ namespace Engine::RenderSystemState {
 
         // call previous readbacks.
         while (!readback.registry.empty()) {
-            auto & fnt = readback.registry.front();
+            auto &fnt = readback.registry.front();
             auto ret = m_system.GetDevice().getFenceStatus(fnt.fence.get());
-            if (ret == vk::Result::eNotReady)    break;
+            if (ret == vk::Result::eNotReady) break;
             if (ret != vk::Result::eSuccess) {
                 throw std::runtime_error(vk::to_string(ret) + " happened when querying status of readback fence.");
             }
 
-            for (auto & itr : fnt.callbacks) {
+            for (auto &itr : fnt.callbacks) {
                 std::invoke(itr.first, std::move(itr.second));
             }
 
@@ -511,15 +496,9 @@ namespace Engine::RenderSystemState {
         return pimpl->timeline_semaphores[GetFrameInFlight()];
     }
 
-    bool FrameManager::RegisterReadbackCallback(
-        const DeviceBuffer & buffer,
-        ReadbackCallback cb
-    ) {
+    bool FrameManager::RegisterReadbackCallback(const DeviceBuffer &buffer, ReadbackCallback cb) {
         if (pimpl->readback.registry.size() >= FRAMES_IN_FLIGHT) {
-            SDL_LogWarn(
-                SDL_LOG_CATEGORY_RENDER,
-                "Too many uncalled callback registry. New request is ignored."
-            );
+            SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "Too many uncalled callback registry. New request is ignored.");
             return false;
         }
 
@@ -528,15 +507,11 @@ namespace Engine::RenderSystemState {
         }
 
         auto staging_buffer = DeviceBuffer::CreateUnique(
-            pimpl->m_system.GetAllocatorState(),
-            BufferType{BufferTypeBits::ReadbackFromDevice},
-            buffer.GetSize()
+            pimpl->m_system.GetAllocatorState(), BufferType{BufferTypeBits::ReadbackFromDevice}, buffer.GetSize()
         );
 
         ReadbackCommand(pimpl->readback.current_registry.combuf.get(), buffer, *staging_buffer);
-        pimpl->readback.current_registry.callbacks.push_back(
-            std::make_pair(cb, std::move(staging_buffer))
-        );
+        pimpl->readback.current_registry.callbacks.push_back(std::make_pair(cb, std::move(staging_buffer)));
         return true;
     }
 } // namespace Engine::RenderSystemState

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -324,9 +324,10 @@ namespace Engine::RenderSystemState {
         const uint32_t fif = GetFrameInFlight();
         auto &this_timeline_semaphore = pimpl->timeline_semaphores[fif];
         auto &prev_timeline_semaphore = pimpl->timeline_semaphores[(fif + (FRAMES_IN_FLIGHT - 1)) % FRAMES_IN_FLIGHT];
-        // TODO: we currently hardcode expected timepoints to be 3, namely: start(1), transfer(2) and render(3).
+        // TODO: we currently hardcode expected timepoints to be 4, namely: start(1), transfer(2), render(3) and presenting(4).
         // This start timepoint is not actually needed other than scilencing the validation layer.
-        this_timeline_semaphore.SetExpectedTimepoints(3);
+        // The presenting timepoint is currently not needed actually as all operations happen on one queue.
+        this_timeline_semaphore.SetExpectedTimepoints(4);
 
         pimpl->m_submission_helper->OnPreMainCbSubmission();
 
@@ -338,6 +339,7 @@ namespace Engine::RenderSystemState {
             // Wait before any command starts.
             vk::PipelineStageFlagBits2::eAllCommands
         );
+        // Wait for total completion of the last frame
         wait_infos[1] = prev_timeline_semaphore.GetSubmitInfo(
             prev_timeline_semaphore.GetExpectedTimepoints(), vk::PipelineStageFlagBits2::eAllCommands
         );
@@ -390,12 +392,12 @@ namespace Engine::RenderSystemState {
         // Prepare submit info for copy commandbuffer
         vk::CommandBufferSubmitInfo cbsi{copy_cb};
         std::array<vk::SemaphoreSubmitInfo, 2> wait_infos{};
-        std::array<vk::SemaphoreSubmitInfo, 1> signal_infos{};
+        std::array<vk::SemaphoreSubmitInfo, 2> signal_infos{};
 
-        // Wait for the last timepoint
+        // Wait for the second-to-last timepoint
         auto &this_frame_semaphore = pimpl->timeline_semaphores[fif];
         wait_infos[0] = this_frame_semaphore.GetSubmitInfo(
-            this_frame_semaphore.GetExpectedTimepoints(), vk::PipelineStageFlagBits2::eAllTransfer
+            this_frame_semaphore.GetExpectedTimepoints() - 1, vk::PipelineStageFlagBits2::eAllTransfer
         );
         // Wait for image acquisition (this is binary).
         wait_infos[1] = vk::SemaphoreSubmitInfo{
@@ -408,6 +410,9 @@ namespace Engine::RenderSystemState {
             0,
             vk::PipelineStageFlagBits2::eAllTransfer
         };
+        signal_infos[1] = this_frame_semaphore.GetSubmitInfo(
+            this_frame_semaphore.GetExpectedTimepoints(), vk::PipelineStageFlagBits2::eAllTransfer
+        );
 
         vk::SubmitInfo2 sinfo{vk::SubmitFlags{}, wait_infos, {cbsi}, signal_infos};
         const auto &queueInfo = pimpl->m_system.GetDeviceInterface().GetQueueInfo();

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -196,10 +196,10 @@ namespace Engine::RenderSystemState {
 
         stcinfo.semaphoreType = vk::SemaphoreType::eTimeline;
         for (uint32_t i = 0; i < FRAMES_IN_FLIGHT; i++) {
-            timeline_semaphores[i].timeline_semaphore = device.createSemaphoreUnique(scinfo);
+            timeline_semaphores[i].SetSemaphore(device.createSemaphoreUnique(scinfo));
             DEBUG_SET_NAME_TEMPLATE(
                 device,
-                timeline_semaphores[i].timeline_semaphore.get(),
+                timeline_semaphores[i].GetSemaphore(),
                 std::format("Semaphore - timeline semaphore {}", i)
             );
         }
@@ -305,14 +305,11 @@ namespace Engine::RenderSystemState {
         pimpl->command_buffers[fif]->reset();
         device.resetFences({fence});
 
-        // Signal start of this frame
+        // Kickstart of this frame
         // Prevent validation layer from complaining
-        if (pimpl->timeline_semaphores[fif].frame_count > 0) {
+        if (pimpl->timeline_semaphores[fif].GetTotalElapsedTimepoints() > 0) {
             device.signalSemaphore(
-                vk::SemaphoreSignalInfo{
-                    pimpl->timeline_semaphores[fif].timeline_semaphore.get(),
-                    pimpl->timeline_semaphores[fif].GetTimepointValue(FrameSemaphore::TimePoint::Pending)
-                }
+                pimpl->timeline_semaphores[fif].GetSignalInfo(1)
             );
         }
 
@@ -336,71 +333,45 @@ namespace Engine::RenderSystemState {
     }
 
     void FrameManager::SubmitMainCommandBuffer() {
+        const uint32_t fif = GetFrameInFlight();
+        auto &this_timeline_semaphore = pimpl->timeline_semaphores[fif];
+        auto &prev_timeline_semaphore = pimpl->timeline_semaphores[(fif + (FRAMES_IN_FLIGHT - 1)) % FRAMES_IN_FLIGHT];
+        // TODO: we currently hardcode expected timepoints to be 3, namely: start(1), transfer(2) and render(3).
+        // This start timepoint is not actually needed other than scilencing the validation layer.
+        this_timeline_semaphore.SetExpectedTimepoints(3);
+
         pimpl->m_submission_helper->OnPreMainCbSubmission();
 
-        uint32_t fif = GetFrameInFlight();
-
         vk::CommandBufferSubmitInfo cbsi{pimpl->command_buffers[fif].get()};
-
         std::array<vk::SemaphoreSubmitInfo, 2> wait_infos{};
         vk::SemaphoreSubmitInfo signal_info{};
-
-        wait_infos[0] = pimpl->timeline_semaphores[fif].GetSubmitInfo(
-            // Currently we wait for transfer finish as there is no pre-compute stage.
-            FrameSemaphore::TimePoint::PreTransferFinished,
+        wait_infos[0] = this_timeline_semaphore.GetSubmitInfo(
+            2,
             // Wait before any command starts.
             vk::PipelineStageFlagBits2::eAllCommands
         );
-        auto &prev_timeline_semaphore = pimpl->timeline_semaphores[(fif + (FRAMES_IN_FLIGHT - 1)) % FRAMES_IN_FLIGHT];
         wait_infos[1] = prev_timeline_semaphore.GetSubmitInfo(
-            FrameSemaphore::TimePoint::CopyToPresentFinished, vk::PipelineStageFlagBits2::eAllCommands
+            prev_timeline_semaphore.GetExpectedTimepoints(),
+            vk::PipelineStageFlagBits2::eAllCommands
         );
-        // Ugly workaround for deadlock on the first frame.
+        // special consideration for deadlock on the first frame.
         if (GetTotalFrame() == 0) {
+            prev_timeline_semaphore.SetExpectedTimepoints(1);
             this->pimpl->m_system.GetDevice().signalSemaphore(
-                vk::SemaphoreSignalInfo{
-                    prev_timeline_semaphore.timeline_semaphore.get(),
-                    prev_timeline_semaphore.GetTimepointValue(FrameSemaphore::TimePoint::CopyToPresentFinished)
-                }
+                prev_timeline_semaphore.GetSignalInfo(prev_timeline_semaphore.GetExpectedTimepoints())
             );
         }
         // We must step frame after wait info is recorded to avoid deadlock.
-        prev_timeline_semaphore.StepFrame();
+        prev_timeline_semaphore.EndFrame();
 
-        signal_info = pimpl->timeline_semaphores[fif].GetSubmitInfo(
-            // Currently we signal directly for the post-compute as there is no post-compute stage.
-            FrameSemaphore::TimePoint::PostComputeFinished,
+        signal_info = this_timeline_semaphore.GetSubmitInfo(
+            this_timeline_semaphore.GetExpectedTimepoints(),
             // Signal after all commands are finished.
             vk::PipelineStageFlagBits2::eAllCommands
         );
 
         this->pimpl->m_system.GetDeviceInterface().GetQueueInfo().graphicsQueue.submit2(
             vk::SubmitInfo2{vk::SubmitFlags{}, wait_infos, {cbsi}, {signal_info}}, nullptr
-        );
-
-        // Record readback commands
-        if (pimpl->readback.post_graphics_commands.empty()) return;
-
-        assert(!pimpl->readback.has_post_graphics_rb[fif]);
-        pimpl->readback.has_post_graphics_rb.set(fif);
-
-        auto rbcb = pimpl->readback.post_graphics_rb_cbs[fif].get();
-        rbcb.begin(vk::CommandBufferBeginInfo{vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
-        while (!pimpl->readback.post_graphics_commands.empty()) {
-            std::invoke(pimpl->readback.post_graphics_commands.front(), rbcb);
-            pimpl->readback.post_graphics_commands.pop();
-        }
-        rbcb.end();
-
-        wait_infos[0] = pimpl->timeline_semaphores[fif].GetSubmitInfo(
-            FrameSemaphore::TimePoint::PostComputeFinished, vk::PipelineStageFlagBits2::eAllTransfer
-        );
-        cbsi.commandBuffer = rbcb;
-
-        pimpl->m_system.GetDevice().resetFences({pimpl->readback.post_graphics_rb_fences[fif].get()});
-        this->pimpl->m_system.GetDeviceInterface().GetQueueInfo().graphicsQueue.submit2(
-            vk::SubmitInfo2{vk::SubmitFlags{}, {wait_infos[0]}, {cbsi}, {}},
-            pimpl->readback.post_graphics_rb_fences[fif].get()
         );
     }
 
@@ -431,11 +402,12 @@ namespace Engine::RenderSystemState {
         // Prepare submit info for copy commandbuffer
         vk::CommandBufferSubmitInfo cbsi{copy_cb};
         std::array<vk::SemaphoreSubmitInfo, 2> wait_infos{};
-        std::array<vk::SemaphoreSubmitInfo, 2> signal_infos{};
+        std::array<vk::SemaphoreSubmitInfo, 1> signal_infos{};
 
-        // Wait for post compute
-        wait_infos[0] = pimpl->timeline_semaphores[fif].GetSubmitInfo(
-            FrameSemaphore::TimePoint::PostComputeFinished, vk::PipelineStageFlagBits2::eAllTransfer
+        // Wait for the last timepoint
+        auto &this_frame_semaphore = pimpl->timeline_semaphores[fif];
+        wait_infos[0] = this_frame_semaphore.GetSubmitInfo(
+            this_frame_semaphore.GetExpectedTimepoints(), vk::PipelineStageFlagBits2::eAllTransfer
         );
         // Wait for image acquisition (this is binary).
         wait_infos[1] = vk::SemaphoreSubmitInfo{
@@ -448,9 +420,6 @@ namespace Engine::RenderSystemState {
             0,
             vk::PipelineStageFlagBits2::eAllTransfer
         };
-        signal_infos[1] = pimpl->timeline_semaphores[fif].GetSubmitInfo(
-            FrameSemaphore::TimePoint::CopyToPresentFinished, vk::PipelineStageFlagBits2::eAllCommands
-        );
 
         vk::SubmitInfo2 sinfo{vk::SubmitFlags{}, wait_infos, {cbsi}, signal_infos};
         const auto &queueInfo = pimpl->m_system.GetDeviceInterface().GetQueueInfo();

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -86,7 +86,8 @@ namespace {
 
     void ReadbackCommand(vk::CommandBuffer cb, const Engine::DeviceBuffer &src, const Engine::DeviceBuffer &dst) {
         using namespace Engine;
-        cb.copyBuffer(src.GetBuffer(), dst.GetBuffer(), vk::BufferCopy{0, 0, vk::WholeSize});
+        assert(src.GetSize() == dst.GetSize());
+        cb.copyBuffer(src.GetBuffer(), dst.GetBuffer(), vk::BufferCopy{0, 0, dst.GetSize()});
     }
 } // namespace
 
@@ -123,7 +124,7 @@ namespace Engine::RenderSystemState {
             bool HasReadback() const { return static_cast<bool>(current_registry.fence); }
 
             void InitializeRegistry(const RenderSystemState::DeviceInterface & di) {
-                if(!current_registry.fence && "Reinitializing readback registry");
+                assert(!current_registry.fence && "Reinitializing readback registry");
                 current_registry.fence = di.GetDevice().createFenceUnique(vk::FenceCreateInfo{});
 
                 auto cbai = vk::CommandBufferAllocateInfo{
@@ -449,17 +450,32 @@ namespace Engine::RenderSystemState {
     }
 
     void FrameManager::impl::CompleteFrame() {
-
         // Record current readbacks.
         if (readback.HasReadback()) {
+            readback.current_registry.combuf->end();
+            // Submit this commandbuffer
+            vk::CommandBufferSubmitInfo cbsi{readback.current_registry.combuf.get()};
+            std::array<vk::SemaphoreSubmitInfo, 1> wait_infos{};
 
-            if (readback.registry.size() >= FRAMES_IN_FLIGHT) {
-                SDL_LogWarn(
-                    SDL_LOG_CATEGORY_RENDER,
-                    "Too many uncalled callback registry. Oldest one will be removed."
-                );
-                readback.registry.pop_front();
-            }
+            // Wait for the last timepoint
+            auto &this_frame_semaphore = timeline_semaphores[current_frame_in_flight];
+            wait_infos[0] = this_frame_semaphore.GetSubmitInfo(
+                this_frame_semaphore.GetExpectedTimepoints(), vk::PipelineStageFlagBits2::eAllCommands
+            );
+
+            const auto &gqueue = m_system.GetDeviceInterface().GetQueueInfo().graphicsQueue;
+            gqueue.submit2(
+                {
+                    vk::SubmitInfo2{
+                        vk::SubmitFlags{},
+                        wait_infos,
+                        {cbsi},
+                        {}
+                    }
+                },
+                readback.current_registry.fence.get()
+            );
+
             readback.AddRegistery();
         }
 
@@ -495,10 +511,18 @@ namespace Engine::RenderSystemState {
         return pimpl->timeline_semaphores[GetFrameInFlight()];
     }
 
-    void FrameManager::RegisterReadbackCallback(
+    bool FrameManager::RegisterReadbackCallback(
         const DeviceBuffer & buffer,
         ReadbackCallback cb
     ) {
+        if (pimpl->readback.registry.size() >= FRAMES_IN_FLIGHT) {
+            SDL_LogWarn(
+                SDL_LOG_CATEGORY_RENDER,
+                "Too many uncalled callback registry. New request is ignored."
+            );
+            return false;
+        }
+
         if (!pimpl->readback.HasReadback()) {
             pimpl->readback.InitializeRegistry(pimpl->m_system.GetDeviceInterface());
         }
@@ -513,5 +537,6 @@ namespace Engine::RenderSystemState {
         pimpl->readback.current_registry.callbacks.push_back(
             std::make_pair(cb, std::move(staging_buffer))
         );
+        return true;
     }
 } // namespace Engine::RenderSystemState

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -299,8 +299,8 @@ namespace Engine::RenderSystemState {
         // Wait for command buffer execution.
         vk::Fence fence = pimpl->command_executed_fences[fif].get();
         vk::Result wait_result = device.waitForFences({fence}, vk::True, timeout);
-        if (wait_result == vk::Result::eTimeout) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Timed out waiting for fence for frame id %u.", fif);
+        if (wait_result != vk::Result::eSuccess) {
+            throw std::runtime_error(vk::to_string(wait_result) + " happened when waiting for frame fences.");
         }
         pimpl->command_buffers[fif]->reset();
         device.resetFences({fence});
@@ -383,7 +383,6 @@ namespace Engine::RenderSystemState {
         vk::Filter filter
     ) {
         const auto fif = GetFrameInFlight();
-        const auto framebuffer_image = this->pimpl->m_system.GetSwapchain().GetImages()[GetFramebuffer()];
         const auto &copy_cb = pimpl->copy_to_swapchain_command_buffers[fif].get();
 
         RecordCopyCommand(
@@ -457,11 +456,14 @@ namespace Engine::RenderSystemState {
     void FrameManager::impl::CompleteFrame() {
 
         if (readback.has_post_graphics_rb[current_frame_in_flight]) {
-            m_system.GetDevice().waitForFences(
+            auto ret = m_system.GetDevice().waitForFences(
                 {readback.post_graphics_rb_fences[current_frame_in_flight].get()},
                 true,
                 std::numeric_limits<uint64_t>::max()
             );
+            if (ret != vk::Result::eSuccess) {
+                throw std::runtime_error(vk::to_string(ret) + " happened when waiting for readback fences.");
+            }
             readback.has_post_graphics_rb.reset(current_frame_in_flight);
             readback.post_graphics_rb_cbs[current_frame_in_flight]->reset();
         }

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -108,6 +108,7 @@ namespace Engine::RenderSystemState {
         // Data and handles used by readback routines.
         struct {
             struct ReadbackRegistry {
+                // TODO: reuse fences and command buffers to avoid frequent reallocation.
                 vk::UniqueFence fence;
                 vk::UniqueCommandBuffer combuf;
                 std::deque <
@@ -450,7 +451,17 @@ namespace Engine::RenderSystemState {
     void FrameManager::impl::CompleteFrame() {
 
         // Record current readbacks.
-        if (readback.HasReadback()) readback.AddRegistery();
+        if (readback.HasReadback()) {
+
+            if (readback.registry.size() >= FRAMES_IN_FLIGHT) {
+                SDL_LogWarn(
+                    SDL_LOG_CATEGORY_RENDER,
+                    "Too many uncalled callback registry. Oldest one will be removed."
+                );
+                readback.registry.pop_front();
+            }
+            readback.AddRegistery();
+        }
 
         // call previous readbacks.
         while (!readback.registry.empty()) {

--- a/engine/Render/RenderSystem/FrameManager.cpp
+++ b/engine/Render/RenderSystem/FrameManager.cpp
@@ -88,27 +88,6 @@ namespace {
         using namespace Engine;
         cb.copyBuffer(src.GetBuffer(), dst.GetBuffer(), vk::BufferCopy{0, 0, vk::WholeSize});
     }
-
-    void ReadbackCommand(
-        vk::CommandBuffer cb,
-        const Engine::Texture &src,
-        vk::ImageAspectFlagBits aspect,
-        uint32_t level,
-        uint32_t layer,
-        vk::Extent3D extent,
-        const Engine::DeviceBuffer &dst
-    ) {
-        using namespace Engine;
-
-        cb.copyImageToBuffer(
-            src.GetImage(),
-            vk::ImageLayout::eTransferSrcOptimal,
-            dst.GetBuffer(),
-            vk::BufferImageCopy{
-                0, 0, 0, vk::ImageSubresourceLayers{aspect, level, layer, 1}, vk::Offset3D{0, 0, 0}, extent
-            }
-        );
-    }
 } // namespace
 
 namespace Engine::RenderSystemState {
@@ -128,10 +107,43 @@ namespace Engine::RenderSystemState {
 
         // Data and handles used by readback routines.
         struct {
-            std::bitset<FRAMES_IN_FLIGHT> has_post_graphics_rb{};
-            std::array<vk::UniqueFence, FRAMES_IN_FLIGHT> post_graphics_rb_fences{};
-            std::array<vk::UniqueCommandBuffer, FRAMES_IN_FLIGHT> post_graphics_rb_cbs{};
-            std::queue<std::function<void(vk::CommandBuffer)>> post_graphics_commands{};
+            struct ReadbackRegistry {
+                vk::UniqueFence fence;
+                vk::UniqueCommandBuffer combuf;
+                std::deque <
+                    std::pair<ReadbackCallback, std::unique_ptr<DeviceBuffer>>
+                > callbacks;
+            };
+
+            ReadbackRegistry current_registry;
+
+            std::deque <ReadbackRegistry> registry;
+
+            bool HasReadback() const { return static_cast<bool>(current_registry.fence); }
+
+            void InitializeRegistry(const RenderSystemState::DeviceInterface & di) {
+                if(!current_registry.fence && "Reinitializing readback registry");
+                current_registry.fence = di.GetDevice().createFenceUnique(vk::FenceCreateInfo{});
+
+                auto cbai = vk::CommandBufferAllocateInfo{
+                    di.GetQueueInfo().graphicsOneTimePool.get(),
+                    vk::CommandBufferLevel::ePrimary,
+                    1
+                };
+                auto onetime_cb = di.GetDevice().allocateCommandBuffersUnique(cbai);
+                current_registry.combuf = std::move(onetime_cb[0]);
+                current_registry.combuf.get().begin(
+                    vk::CommandBufferBeginInfo{vk::CommandBufferUsageFlagBits::eOneTimeSubmit}
+                );
+            }
+
+            void AddRegistery() {
+                registry.push_back(std::move(current_registry));
+
+                current_registry.fence.reset();
+                current_registry.combuf.reset();
+                current_registry.callbacks.clear();
+            }
         } readback{};
 
         uint32_t current_frame_in_flight{std::numeric_limits<uint32_t>::max()};
@@ -143,6 +155,12 @@ namespace Engine::RenderSystemState {
         RenderSystem &m_system;
 
         std::unique_ptr<SubmissionHelper> m_submission_helper{};
+
+        void assert_in_frame() const {
+            if (current_framebuffer == std::numeric_limits<uint32_t>::max()) {
+                throw std::runtime_error("This method must be called between StartFrame and CompleteFrame");
+            }
+        }
 
         /// @brief Progress the frame state machine.
         void CompleteFrame();
@@ -175,13 +193,6 @@ namespace Engine::RenderSystemState {
             command_executed_fences[i] = device.createFenceUnique(finfo);
             DEBUG_SET_NAME_TEMPLATE(
                 device, command_executed_fences[i].get(), std::format("Fence - all commands executed {}", i)
-            );
-
-            readback.post_graphics_rb_fences[i] = device.createFenceUnique(finfo);
-            DEBUG_SET_NAME_TEMPLATE(
-                device,
-                readback.post_graphics_rb_fences[i].get(),
-                std::format("Fence - post graphics readback executed {}", i)
             );
         }
         copy_to_swapchain_completed_semaphores.resize(m_system.GetSwapchain().GetFrameCount());
@@ -231,21 +242,6 @@ namespace Engine::RenderSystemState {
             );
         }
 
-        // Readback command buffers
-        new_command_buffers = device.allocateCommandBuffersUnique(
-            vk::CommandBufferAllocateInfo{
-                queue_info.graphicsPool.get(), vk::CommandBufferLevel::ePrimary, FRAMES_IN_FLIGHT
-            }
-        );
-        for (uint32_t i = 0; i < FRAMES_IN_FLIGHT; i++) {
-            readback.post_graphics_rb_cbs[i] = std::move(new_command_buffers[i]);
-            DEBUG_SET_NAME_TEMPLATE(
-                device,
-                readback.post_graphics_rb_cbs[i].get(),
-                std::format("Command buffer - post graphics readback {}", i)
-            );
-        }
-
         current_frame_in_flight = 0;
         m_submission_helper = std::make_unique<SubmissionHelper>(m_system);
     }
@@ -264,18 +260,12 @@ namespace Engine::RenderSystemState {
     }
 
     uint32_t FrameManager::GetFramebuffer() const noexcept {
-        assert(
-            this->pimpl->current_framebuffer < std::numeric_limits<uint32_t>::max()
-            && "Frame Manager is in invalid state."
-        );
+        pimpl->assert_in_frame();
         return this->pimpl->current_framebuffer;
     }
 
     GraphicsCommandBuffer FrameManager::GetCommandBuffer() {
-        assert(
-            this->pimpl->current_framebuffer < std::numeric_limits<uint32_t>::max()
-            && "Frame Manager is in invalid state."
-        );
+        pimpl->assert_in_frame();
         return GraphicsCommandBuffer(pimpl->m_system, GetRawMainCommandBuffer(), GetFrameInFlight());
     }
 
@@ -333,6 +323,8 @@ namespace Engine::RenderSystemState {
     }
 
     void FrameManager::SubmitMainCommandBuffer() {
+        pimpl->assert_in_frame();
+
         const uint32_t fif = GetFrameInFlight();
         auto &this_timeline_semaphore = pimpl->timeline_semaphores[fif];
         auto &prev_timeline_semaphore = pimpl->timeline_semaphores[(fif + (FRAMES_IN_FLIGHT - 1)) % FRAMES_IN_FLIGHT];
@@ -382,6 +374,8 @@ namespace Engine::RenderSystemState {
         vk::Offset2D offsetSrc,
         vk::Filter filter
     ) {
+        pimpl->assert_in_frame();
+
         const auto fif = GetFrameInFlight();
         const auto &copy_cb = pimpl->copy_to_swapchain_command_buffers[fif].get();
 
@@ -455,17 +449,23 @@ namespace Engine::RenderSystemState {
 
     void FrameManager::impl::CompleteFrame() {
 
-        if (readback.has_post_graphics_rb[current_frame_in_flight]) {
-            auto ret = m_system.GetDevice().waitForFences(
-                {readback.post_graphics_rb_fences[current_frame_in_flight].get()},
-                true,
-                std::numeric_limits<uint64_t>::max()
-            );
+        // Record current readbacks.
+        if (readback.HasReadback()) readback.AddRegistery();
+
+        // call previous readbacks.
+        while (!readback.registry.empty()) {
+            auto & fnt = readback.registry.front();
+            auto ret = m_system.GetDevice().getFenceStatus(fnt.fence.get());
+            if (ret == vk::Result::eNotReady)    break;
             if (ret != vk::Result::eSuccess) {
-                throw std::runtime_error(vk::to_string(ret) + " happened when waiting for readback fences.");
+                throw std::runtime_error(vk::to_string(ret) + " happened when querying status of readback fence.");
             }
-            readback.has_post_graphics_rb.reset(current_frame_in_flight);
-            readback.post_graphics_rb_cbs[current_frame_in_flight]->reset();
+
+            for (auto & itr : fnt.callbacks) {
+                std::invoke(itr.first, std::move(itr.second));
+            }
+
+            readback.registry.pop_front();
         }
 
         // Increment FIF counter, reset framebuffer index
@@ -482,5 +482,25 @@ namespace Engine::RenderSystemState {
     }
     const FrameSemaphore &FrameManager::GetFrameSemaphore() const noexcept {
         return pimpl->timeline_semaphores[GetFrameInFlight()];
+    }
+
+    void FrameManager::RegisterReadbackCallback(
+        const DeviceBuffer & buffer,
+        ReadbackCallback cb
+    ) {
+        if (!pimpl->readback.HasReadback()) {
+            pimpl->readback.InitializeRegistry(pimpl->m_system.GetDeviceInterface());
+        }
+
+        auto staging_buffer = DeviceBuffer::CreateUnique(
+            pimpl->m_system.GetAllocatorState(),
+            BufferType{BufferTypeBits::ReadbackFromDevice},
+            buffer.GetSize()
+        );
+
+        ReadbackCommand(pimpl->readback.current_registry.combuf.get(), buffer, *staging_buffer);
+        pimpl->readback.current_registry.callbacks.push_back(
+            std::make_pair(cb, std::move(staging_buffer))
+        );
     }
 } // namespace Engine::RenderSystemState

--- a/engine/Render/RenderSystem/FrameManager.h
+++ b/engine/Render/RenderSystem/FrameManager.h
@@ -1,6 +1,7 @@
 #ifndef RENDER_RENDERSYSTEM_FRAMEMANAGER_INCLUDED
 #define RENDER_RENDERSYSTEM_FRAMEMANAGER_INCLUDED
 
+#include <functional>
 // May be safe to include here as this header is not included in other headers.
 #include <vulkan/vulkan.hpp>
 
@@ -144,6 +145,34 @@ namespace Engine {
 
             /// @brief Get the current frame semaphore.
             const FrameSemaphore &GetFrameSemaphore() const noexcept;
+
+            /**
+             * @brief Function type of callback of readback operations.
+             * 
+             * Data retrieved from the device is stored in the device buffer.
+             * This buffer can be mapped to the host VM for reading.
+             */
+            using ReadbackCallback = std::function<void(std::unique_ptr <DeviceBuffer>)>;
+            /**
+             * @brief Register a callback for buffer or texture readback.
+             * 
+             * The callback is associated with the current frame-in-flight.
+             * After all command buffers in the current frame-in-flight are
+             * completed, a special command buffer containing copying commands
+             * will be executed.
+             * 
+             * On completion of subsequent frames, registered callbacks will be
+             * executed if the copying is completed.
+             * Typically a delay of one to two frames can be expected.
+             * 
+             * This readback supports buffer only to avoid dealing with layout
+             * transition problem. Issue a copy to buffer command in your 
+             * rendering loop to copy your texture to a buffer first.
+             */
+            void RegisterReadbackCallback(
+                const DeviceBuffer & buffer,
+                ReadbackCallback cb
+            );
         };
     } // namespace RenderSystemState
 } // namespace Engine

--- a/engine/Render/RenderSystem/FrameManager.h
+++ b/engine/Render/RenderSystem/FrameManager.h
@@ -148,35 +148,32 @@ namespace Engine {
 
             /**
              * @brief Function type of callback of readback operations.
-             * 
+             *
              * Data retrieved from the device is stored in the device buffer.
              * This buffer can be mapped to the host VM for reading.
              */
-            using ReadbackCallback = std::function<void(std::unique_ptr <DeviceBuffer>)>;
+            using ReadbackCallback = std::function<void(std::unique_ptr<DeviceBuffer>)>;
             /**
              * @brief Register a callback for buffer or texture readback.
-             * 
+             *
              * The callback is associated with the current frame-in-flight.
              * After all command buffers in the current frame-in-flight are
              * completed, a special command buffer containing copying commands
              * will be executed.
-             * 
+             *
              * On completion of subsequent frames, registered callbacks will be
              * executed if the copying is completed.
              * Typically a delay of one to two frames can be expected.
-             * 
+             *
              * This readback supports buffer only to avoid dealing with layout
-             * transition problem. Issue a copy to buffer command in your 
+             * transition problem. Issue a copy to buffer command in your
              * rendering loop to copy your texture to a buffer first.
-             * 
+             *
              * @return Whether the callback can be added to current frame-in-flight.
              * If too many readback requests are not fulfilled, the registering
              * might fail.
              */
-            bool RegisterReadbackCallback(
-                const DeviceBuffer & buffer,
-                ReadbackCallback cb
-            );
+            bool RegisterReadbackCallback(const DeviceBuffer &buffer, ReadbackCallback cb);
         };
     } // namespace RenderSystemState
 } // namespace Engine

--- a/engine/Render/RenderSystem/FrameManager.h
+++ b/engine/Render/RenderSystem/FrameManager.h
@@ -144,40 +144,6 @@ namespace Engine {
 
             /// @brief Get the current frame semaphore.
             const FrameSemaphore &GetFrameSemaphore() const noexcept;
-
-            /// Buffer Readback operations
-
-            /**
-             * @brief Enqueue a post graphics readback from GPU to CPU host memory.
-             *
-             * While readback commands are submitted to GPU on main commandbuffer submission,
-             * data will not be available until the frame has completed.
-             *
-             * This method performs no sychronization operation apart from the semaphore
-             * wait on the submission of the readback commandbuffer.
-             *
-             * @return a staging buffer, whose content is undetermined until
-             * this frame has completed.
-             */
-            std::shared_ptr<DeviceBuffer> EnqueuePostGraphicsBufferReadback(const DeviceBuffer &device_buffer);
-
-            /**
-             * @brief Enqueue a post graphics readback from GPU to CPU host memory.
-             *
-             * While readback commands are submitted to GPU on main commandbuffer submission,
-             * data will not be available until the frame has completed.
-             *
-             * This method performs no sychronization operation apart from the semaphore
-             * wait on the submission of the readback commandbuffer.
-             * The texture is assumed to be in `GENERAL` layout.
-             * Only color aspect is read back.
-             *
-             * @return a staging buffer, whose content is undetermined until
-             * this frame has completed.
-             */
-            std::shared_ptr<DeviceBuffer> EnqueuePostGraphicsImageReadback(
-                const Texture &image, uint32_t array_layer, uint32_t miplevel
-            );
         };
     } // namespace RenderSystemState
 } // namespace Engine

--- a/engine/Render/RenderSystem/FrameManager.h
+++ b/engine/Render/RenderSystem/FrameManager.h
@@ -168,8 +168,12 @@ namespace Engine {
              * This readback supports buffer only to avoid dealing with layout
              * transition problem. Issue a copy to buffer command in your 
              * rendering loop to copy your texture to a buffer first.
+             * 
+             * @return Whether the callback can be added to current frame-in-flight.
+             * If too many readback requests are not fulfilled, the registering
+             * might fail.
              */
-            void RegisterReadbackCallback(
+            bool RegisterReadbackCallback(
                 const DeviceBuffer & buffer,
                 ReadbackCallback cb
             );

--- a/engine/Render/RenderSystem/FrameSemaphore.hpp
+++ b/engine/Render/RenderSystem/FrameSemaphore.hpp
@@ -5,39 +5,73 @@
 #include <vulkan/vulkan.hpp>
 
 namespace Engine::RenderSystemState {
-    struct FrameSemaphore final {
-        vk::UniqueSemaphore timeline_semaphore;
-        uint64_t frame_count;
+    /**
+     * @brief Simple, frame-based wrapper around Vulkan timeline semaphore.
+     */
+    class FrameSemaphore {
+        vk::UniqueSemaphore timeline_semaphore {nullptr};
+        uint32_t current_frame_expected_timepoints {0};
+        uint64_t total_elapsed_timepoints {0};
+    
+    public:
+        void SetSemaphore(vk::UniqueSemaphore && s) noexcept { timeline_semaphore = std::move(s); }
+        vk::Semaphore GetSemaphore() const noexcept { return timeline_semaphore.get(); }
+        uint32_t GetExpectedTimepoints() const noexcept { return current_frame_expected_timepoints; }
+        uint64_t GetTotalElapsedTimepoints() const noexcept { return total_elapsed_timepoints; }
 
-        enum class TimePoint {
-            Pending,
-            PreTransferFinished,
-            PreComputeFinished,
-            // XXX: investigate possible optimization opportunity.
-            // maybe we should split GUI drawing from main graphics and run GUI in parallel with post compute.
-            // (See https://docs.vulkan.org/samples/latest/samples/performance/async_compute/README.html)
-            // in that case the post compute finished semaphore should be renamed to `GUIFinished`,
-            // as dependency in the same async compute queue can be expressed by barriers instead of semaphores.
-            // Or we can run post-process compute in main graphics queue and leave post compute for composition only.
-            GraphicFinished,
-            PostComputeFinished,
-            // While `VkPresentInfoKHR` only accepts binary semaphore, we still need this to prevent writing on textures being copied to present.
-            CopyToPresentFinished,
-            MAX_TIME_POINTS
-        };
-
-        void StepFrame() {
-            frame_count++;
+        /**
+         * @brief Step the frame by adding expected timepoints to the elapsed
+         * counter.
+         * 
+         * The expected timepoints of the previous frame is not zeroed. You can
+         * use `GetExpectedTimepoints()` to query this value until the next call
+         * of `SetExpectedTimepoints()`.
+         */
+        void EndFrame() noexcept {
+            assert(current_frame_expected_timepoints > 0 && "Expected timepoints of the current frame is not set yet.");
+            total_elapsed_timepoints += current_frame_expected_timepoints;
         }
 
-        uint64_t GetTimepointValue(TimePoint timepoint) const noexcept {
-            return frame_count * std::underlying_type_t<TimePoint>(TimePoint::MAX_TIME_POINTS)
-                   + std::underlying_type_t<TimePoint>(timepoint);
+        /**
+         * @brief Set the expected synchronization timepoint of the current
+         * frame.
+         * 
+         * Depending on the render process of the current frame, multiple
+         * synchronization timepoints might be necessary. Typically, following
+         * procedures needs its timepoint:
+         * 
+         * - Start of the frame;
+         * - Submission of host data to device;
+         * - Pre-rendering compute, if it is distributed to another queue;
+         * - Rendering passes;
+         * - Post-processing compute, if it is distributed to another queue;
+         * - Presenting.
+         * 
+         * Start of the frame is needed to kickstart the frame without the
+         * validation layer complaining.
+         * Synchronization within rendering passes are managed by barriers.
+         * Therefore, no timepoints are needed.
+         */
+        void SetExpectedTimepoints(uint32_t timepoints) {
+            assert(timepoints > 0 && "Timepoints of any frame should be greater than zero.");
+            current_frame_expected_timepoints = timepoints;
         }
 
-        vk::SemaphoreSubmitInfo GetSubmitInfo(TimePoint timepoint, vk::PipelineStageFlags2 stage) const noexcept {
+        uint64_t GetTimepointValue(uint32_t timepoint) const noexcept {
+            assert(timepoint <= current_frame_expected_timepoints && "Timepoint out of range.");
+            return total_elapsed_timepoints + timepoint;
+        }
+
+        vk::SemaphoreSubmitInfo GetSubmitInfo(uint32_t timepoint, vk::PipelineStageFlags2 stage) const noexcept {
             assert(timeline_semaphore);
+            assert(timepoint <= current_frame_expected_timepoints && "Timepoint out of range.");
             return vk::SemaphoreSubmitInfo{timeline_semaphore.get(), GetTimepointValue(timepoint), stage};
+        }
+
+        vk::SemaphoreSignalInfo GetSignalInfo(uint32_t timepoint) const noexcept {
+            assert(timeline_semaphore);
+            assert(timepoint <= current_frame_expected_timepoints && "Timepoint out of range.");
+            return vk::SemaphoreSignalInfo{timeline_semaphore.get(), GetTimepointValue(timepoint)};
         }
     };
 } // namespace Engine::RenderSystemState

--- a/engine/Render/RenderSystem/FrameSemaphore.hpp
+++ b/engine/Render/RenderSystem/FrameSemaphore.hpp
@@ -9,20 +9,28 @@ namespace Engine::RenderSystemState {
      * @brief Simple, frame-based wrapper around Vulkan timeline semaphore.
      */
     class FrameSemaphore {
-        vk::UniqueSemaphore timeline_semaphore {nullptr};
-        uint32_t current_frame_expected_timepoints {0};
-        uint64_t total_elapsed_timepoints {0};
-    
+        vk::UniqueSemaphore timeline_semaphore{nullptr};
+        uint32_t current_frame_expected_timepoints{0};
+        uint64_t total_elapsed_timepoints{0};
+
     public:
-        void SetSemaphore(vk::UniqueSemaphore && s) noexcept { timeline_semaphore = std::move(s); }
-        vk::Semaphore GetSemaphore() const noexcept { return timeline_semaphore.get(); }
-        uint32_t GetExpectedTimepoints() const noexcept { return current_frame_expected_timepoints; }
-        uint64_t GetTotalElapsedTimepoints() const noexcept { return total_elapsed_timepoints; }
+        void SetSemaphore(vk::UniqueSemaphore &&s) noexcept {
+            timeline_semaphore = std::move(s);
+        }
+        vk::Semaphore GetSemaphore() const noexcept {
+            return timeline_semaphore.get();
+        }
+        uint32_t GetExpectedTimepoints() const noexcept {
+            return current_frame_expected_timepoints;
+        }
+        uint64_t GetTotalElapsedTimepoints() const noexcept {
+            return total_elapsed_timepoints;
+        }
 
         /**
          * @brief Step the frame by adding expected timepoints to the elapsed
          * counter.
-         * 
+         *
          * The expected timepoints of the previous frame is not zeroed. You can
          * use `GetExpectedTimepoints()` to query this value until the next call
          * of `SetExpectedTimepoints()`.
@@ -35,18 +43,18 @@ namespace Engine::RenderSystemState {
         /**
          * @brief Set the expected synchronization timepoint of the current
          * frame.
-         * 
+         *
          * Depending on the render process of the current frame, multiple
          * synchronization timepoints might be necessary. Typically, following
          * procedures needs its timepoint:
-         * 
+         *
          * - Start of the frame;
          * - Submission of host data to device;
          * - Pre-rendering compute, if it is distributed to another queue;
          * - Rendering passes;
          * - Post-processing compute, if it is distributed to another queue;
          * - Presenting.
-         * 
+         *
          * Start of the frame is needed to kickstart the frame without the
          * validation layer complaining.
          * Synchronization within rendering passes are managed by barriers.

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -213,7 +213,11 @@ namespace Engine::RenderSystemState {
         if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
             throw std::invalid_argument("Selected texture does not contain color aspect.");
         }
-        auto staging_buffer{texture.CreateStagingBuffer(m_system.GetAllocatorState())};
+        auto staging_buffer = DeviceBuffer::CreateUnique(
+            this->m_system.GetAllocatorState(),
+            {BufferTypeBits::StagingToDevice}, texture.CalculateStagingBufferSizeNoMipmap(),
+            "Staging buffer"
+        );
         if(data.size_bytes() > staging_buffer->GetSize()) {
             throw std::invalid_argument("Too many data to be uploaded to texture.");
         }

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -242,56 +242,6 @@ namespace Engine::RenderSystemState {
         pimpl->m_pending_operations.push(enqueued);
     }
 
-    void SubmissionHelper::EnqueueBufferSubmissionVertex(
-        const DeviceBuffer &vertex_buffer, const std::vector<std::byte> &data
-    ) {
-        auto staging_buffer = DeviceBuffer::CreateUnique(
-            this->m_system.GetAllocatorState(),
-            {BufferTypeBits::StagingToDevice},
-            vertex_buffer.GetSize(),
-            "Staging buffer"
-        );
-        std::memcpy(staging_buffer->GetVMAddress(), data.data(), vertex_buffer.GetSize());
-        staging_buffer->Flush();
-
-        auto enqueued =
-            [data = std::move(data), &vertex_buffer, this, pbuf = staging_buffer.get()](vk::CommandBuffer cb) {
-                auto mbarrier = GetBufferBarrier(BufferTransferType::VertexBefore);
-                std::array<vk::BufferMemoryBarrier2, 1> barriers{};
-                barriers[0] = {
-                    mbarrier.srcStageMask,
-                    mbarrier.srcAccessMask,
-                    mbarrier.dstStageMask,
-                    mbarrier.dstAccessMask,
-                    vk::QueueFamilyIgnored,
-                    vk::QueueFamilyIgnored,
-                    vertex_buffer.GetBuffer(),
-                    0,
-                    vertex_buffer.GetSize()
-                };
-
-                cb.pipelineBarrier2(vk::DependencyInfo{{}, {}, barriers, {}});
-                vk::BufferCopy copy{0, 0, static_cast<vk::DeviceSize>(vertex_buffer.GetSize())};
-                cb.copyBuffer(pbuf->GetBuffer(), vertex_buffer.GetBuffer(), {copy});
-
-                mbarrier = GetBufferBarrier(BufferTransferType::VertexAfter);
-                barriers[0] = {
-                    mbarrier.srcStageMask,
-                    mbarrier.srcAccessMask,
-                    mbarrier.dstStageMask,
-                    mbarrier.dstAccessMask,
-                    vk::QueueFamilyIgnored,
-                    vk::QueueFamilyIgnored,
-                    vertex_buffer.GetBuffer(),
-                    0,
-                    vertex_buffer.GetSize()
-                };
-                cb.pipelineBarrier2(vk::DependencyInfo{{}, {}, barriers, {}});
-            };
-        pimpl->m_pending_dellocations.push_back(std::move(staging_buffer));
-        pimpl->m_pending_operations.push(enqueued);
-    }
-
     void SubmissionHelper::EnqueueTextureBufferSubmission(
         const Texture &texture, const std::byte *data, size_t length
     ) {

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -155,17 +155,22 @@ namespace Engine::RenderSystemState {
 
     SubmissionHelper::~SubmissionHelper() = default;
 
-    void SubmissionHelper::EnqueueBufferSubmission(const DeviceBuffer &buffer, std::vector<std::byte> &&data) {
-        assert(data.size() >= buffer.GetSize());
+    void SubmissionHelper::EnqueueBufferSubmission(
+        const DeviceBuffer &buffer,
+        std::span<const std::byte> data,
+        size_t buffer_offset
+    ) {
+        if (buffer_offset + data.size_bytes() > buffer.GetSize()) {
+            throw std::invalid_argument("Too many bytes of data are submitted to the buffer.");
+        }
 
         auto staging_buffer = DeviceBuffer::CreateUnique(
             this->m_system.GetAllocatorState(), {BufferTypeBits::StagingToDevice}, buffer.GetSize(), "Staging buffer"
         );
         std::memcpy(staging_buffer->GetVMAddress(), data.data(), buffer.GetSize());
         staging_buffer->Flush();
-        data.clear();
 
-        auto enqueued = [data = std::move(data), &buffer, this, pbuf = staging_buffer.get()](vk::CommandBuffer cb) {
+        auto enqueued = [data, &buffer, this, pbuf = staging_buffer.get(), buffer_offset](vk::CommandBuffer cb) {
             auto mbarrier = GetBufferBarrier(BufferTransferType::GeneralTransferBefore);
             std::array<vk::BufferMemoryBarrier2, 1> barriers{};
             barriers[0] = {
@@ -176,11 +181,12 @@ namespace Engine::RenderSystemState {
                 vk::QueueFamilyIgnored,
                 vk::QueueFamilyIgnored,
                 buffer.GetBuffer(),
-                buffer.GetSize()
+                buffer_offset,
+                data.size_bytes()
             };
 
             cb.pipelineBarrier2(vk::DependencyInfo{{}, {}, barriers, {}});
-            vk::BufferCopy copy{0, 0, static_cast<vk::DeviceSize>(buffer.GetSize())};
+            vk::BufferCopy copy{0, buffer_offset, static_cast<vk::DeviceSize>(data.size_bytes())};
             cb.copyBuffer(pbuf->GetBuffer(), buffer.GetBuffer(), {copy});
 
             mbarrier = GetBufferBarrier(BufferTransferType::GeneralTransferAfter);
@@ -192,49 +198,8 @@ namespace Engine::RenderSystemState {
                 vk::QueueFamilyIgnored,
                 vk::QueueFamilyIgnored,
                 buffer.GetBuffer(),
-                buffer.GetSize()
-            };
-            cb.pipelineBarrier2(vk::DependencyInfo{{}, {}, barriers, {}});
-        };
-        pimpl->m_pending_dellocations.push_back(std::move(staging_buffer));
-        pimpl->m_pending_operations.push(enqueued);
-    }
-
-    void SubmissionHelper::EnqueueBufferSubmission(const DeviceBuffer &buffer, const std::vector<std::byte> &data) {
-        auto staging_buffer = DeviceBuffer::CreateUnique(
-            this->m_system.GetAllocatorState(), {BufferTypeBits::StagingToDevice}, buffer.GetSize(), "Staging buffer"
-        );
-        std::memcpy(staging_buffer->GetVMAddress(), data.data(), buffer.GetSize());
-        staging_buffer->Flush();
-
-        auto enqueued = [data = std::move(data), &buffer, this, pbuf = staging_buffer.get()](vk::CommandBuffer cb) {
-            auto mbarrier = GetBufferBarrier(BufferTransferType::GeneralTransferBefore);
-            std::array<vk::BufferMemoryBarrier2, 1> barriers{};
-            barriers[0] = {
-                mbarrier.srcStageMask,
-                mbarrier.srcAccessMask,
-                mbarrier.dstStageMask,
-                mbarrier.dstAccessMask,
-                vk::QueueFamilyIgnored,
-                vk::QueueFamilyIgnored,
-                buffer.GetBuffer(),
-                buffer.GetSize()
-            };
-
-            cb.pipelineBarrier2(vk::DependencyInfo{{}, {}, barriers, {}});
-            vk::BufferCopy copy{0, 0, static_cast<vk::DeviceSize>(buffer.GetSize())};
-            cb.copyBuffer(pbuf->GetBuffer(), buffer.GetBuffer(), {copy});
-
-            mbarrier = GetBufferBarrier(BufferTransferType::GeneralTransferAfter);
-            barriers[0] = {
-                mbarrier.srcStageMask,
-                mbarrier.srcAccessMask,
-                mbarrier.dstStageMask,
-                mbarrier.dstAccessMask,
-                vk::QueueFamilyIgnored,
-                vk::QueueFamilyIgnored,
-                buffer.GetBuffer(),
-                buffer.GetSize()
+                buffer_offset,
+                data.size_bytes()
             };
             cb.pipelineBarrier2(vk::DependencyInfo{{}, {}, barriers, {}});
         };
@@ -243,17 +208,21 @@ namespace Engine::RenderSystemState {
     }
 
     void SubmissionHelper::EnqueueTextureBufferSubmission(
-        const Texture &texture, const std::byte *data, size_t length
+        const Texture &texture, std::span<const std::byte> data
     ) {
-        assert(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor);
-
+        if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
+            throw std::invalid_argument("Selected texture does not contain color aspect.");
+        }
         auto staging_buffer{texture.CreateStagingBuffer(m_system.GetAllocatorState())};
-        assert(length <= staging_buffer->GetSize());
+        if(data.size_bytes() > staging_buffer->GetSize()) {
+            throw std::invalid_argument("Too many data to be uploaded to texture.");
+        }
+
         std::byte *mapped_ptr = staging_buffer->GetVMAddress();
-        std::memcpy(mapped_ptr, data, length);
+        std::memcpy(mapped_ptr, data.data(), data.size_bytes());
         staging_buffer->Flush();
 
-        auto enqueued = [&texture, pbuf = staging_buffer.get(), data, length, this](vk::CommandBuffer cb) {
+        auto enqueued = [&texture, pbuf = staging_buffer.get(), data, this](vk::CommandBuffer cb) {
             // Transit layout to TransferDstOptimal
             std::array<vk::ImageMemoryBarrier2, 1> barriers = {GetTextureBarrier(
                 TextureTransferType::TextureUploadBefore,
@@ -297,7 +266,9 @@ namespace Engine::RenderSystemState {
     }
 
     void SubmissionHelper::EnqueueTextureClear(const Texture &texture, std::tuple<float, float, float, float> color) {
-        assert(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor);
+        if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
+            throw std::invalid_argument("Selected texture does not contain color aspect.");
+        }
 
         auto enqueued = [&texture, color, this](vk::CommandBuffer cb) {
             // Transit layout to TransferDstOptimal
@@ -327,8 +298,12 @@ namespace Engine::RenderSystemState {
     }
 
     void SubmissionHelper::EnqueueTextureClear(const Texture &texture, float depth) {
-        assert(0.0f <= depth && depth <= 1.0f);
-        assert(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eDepth);
+        if (!(0.0f <= depth && depth <= 1.0f)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "Depth clear value %f is not in the range of [0.0, 1.0].", depth);
+        }
+        if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eDepth)) {
+            throw std::invalid_argument("Selected texture does not contain depth aspect.");
+        }
 
         auto enqueued = [&texture, depth, this](vk::CommandBuffer cb) {
             // Transit layout to TransferDstOptimal

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -412,10 +412,7 @@ namespace Engine::RenderSystemState {
             // We do not need to worry about synchronization too much
             // as timeline semaphores are guaranteed to be monotonically increasing.
             m_system.GetDevice().signalSemaphore(
-                vk::SemaphoreSignalInfo{
-                    frame_semaphore.timeline_semaphore.get(),
-                    frame_semaphore.GetTimepointValue(FrameSemaphore::TimePoint::PreTransferFinished)
-                }
+                frame_semaphore.GetSignalInfo(2)
             );
             return;
         }
@@ -442,14 +439,13 @@ namespace Engine::RenderSystemState {
         DEBUG_CMD_END_LABEL(pimpl->m_one_time_cb.get());
         pimpl->m_one_time_cb->end();
 
-        vk::SemaphoreSubmitInfo wait_info{}, signal_info{};
-        wait_info =
-            frame_semaphore.GetSubmitInfo(FrameSemaphore::TimePoint::Pending, vk::PipelineStageFlagBits2::eAllCommands);
+        vk::SemaphoreSubmitInfo signal_info{};
         signal_info = frame_semaphore.GetSubmitInfo(
-            FrameSemaphore::TimePoint::PreTransferFinished, vk::PipelineStageFlagBits2::eAllTransfer
+            2, vk::PipelineStageFlagBits2::eAllTransfer
         );
         vk::CommandBufferSubmitInfo cbsinfo{pimpl->m_one_time_cb.get()};
-        vk::SubmitInfo2 sinfo{vk::SubmitFlags{}, {wait_info}, {cbsinfo}, {signal_info}};
+        // We don't need to wait for anything thanks to fences in the frame manager.
+        vk::SubmitInfo2 sinfo{vk::SubmitFlags{}, {}, {cbsinfo}, {signal_info}};
         queue_info.graphicsQueue.submit2(sinfo, pimpl->m_completion_fence.get());
     }
 

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -479,7 +479,10 @@ namespace Engine::RenderSystemState {
         vk::CommandBufferSubmitInfo cbsinfo{cb.get()};
         vk::SubmitInfo2 sinfo{vk::SubmitFlags{}, {}, {cbsinfo}, {}};
         queue_info.graphicsQueue.submit2(sinfo, fence.get());
-        m_system.GetDevice().waitForFences({fence.get()}, true, std::numeric_limits<uint64_t>::max());
+        auto ret = m_system.GetDevice().waitForFences({fence.get()}, true, std::numeric_limits<uint64_t>::max());
+        if (ret != vk::Result::eSuccess) {
+            throw std::runtime_error(vk::to_string(ret) + " happened when waiting for immediate submission fences.");
+        }
         pimpl->m_pending_dellocations.clear();
     }
 
@@ -494,7 +497,7 @@ namespace Engine::RenderSystemState {
             {pimpl->m_completion_fence.get()}, true, std::numeric_limits<uint64_t>::max()
         );
         if (wfresult != vk::Result::eSuccess) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "An error occured when waiting for submission fence.");
+            throw std::runtime_error(vk::to_string(wfresult) + " happened when waiting for submission fences.");
         }
 
         m_system.GetDevice().resetFences({pimpl->m_completion_fence.get()});

--- a/engine/Render/RenderSystem/SubmissionHelper.cpp
+++ b/engine/Render/RenderSystem/SubmissionHelper.cpp
@@ -156,9 +156,7 @@ namespace Engine::RenderSystemState {
     SubmissionHelper::~SubmissionHelper() = default;
 
     void SubmissionHelper::EnqueueBufferSubmission(
-        const DeviceBuffer &buffer,
-        std::span<const std::byte> data,
-        size_t buffer_offset
+        const DeviceBuffer &buffer, std::span<const std::byte> data, size_t buffer_offset
     ) {
         if (buffer_offset + data.size_bytes() > buffer.GetSize()) {
             throw std::invalid_argument("Too many bytes of data are submitted to the buffer.");
@@ -207,18 +205,17 @@ namespace Engine::RenderSystemState {
         pimpl->m_pending_operations.push(enqueued);
     }
 
-    void SubmissionHelper::EnqueueTextureBufferSubmission(
-        const Texture &texture, std::span<const std::byte> data
-    ) {
-        if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
+    void SubmissionHelper::EnqueueTextureBufferSubmission(const Texture &texture, std::span<const std::byte> data) {
+        if (!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
             throw std::invalid_argument("Selected texture does not contain color aspect.");
         }
         auto staging_buffer = DeviceBuffer::CreateUnique(
             this->m_system.GetAllocatorState(),
-            {BufferTypeBits::StagingToDevice}, texture.CalculateStagingBufferSizeNoMipmap(),
+            {BufferTypeBits::StagingToDevice},
+            texture.CalculateStagingBufferSizeNoMipmap(),
             "Staging buffer"
         );
-        if(data.size_bytes() > staging_buffer->GetSize()) {
+        if (data.size_bytes() > staging_buffer->GetSize()) {
             throw std::invalid_argument("Too many data to be uploaded to texture.");
         }
 
@@ -270,7 +267,7 @@ namespace Engine::RenderSystemState {
     }
 
     void SubmissionHelper::EnqueueTextureClear(const Texture &texture, std::tuple<float, float, float, float> color) {
-        if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
+        if (!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eColor)) {
             throw std::invalid_argument("Selected texture does not contain color aspect.");
         }
 
@@ -305,7 +302,7 @@ namespace Engine::RenderSystemState {
         if (!(0.0f <= depth && depth <= 1.0f)) {
             SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "Depth clear value %f is not in the range of [0.0, 1.0].", depth);
         }
-        if(!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eDepth)) {
+        if (!(ImageUtils::GetVkAspect(texture.GetTextureDescription().format) & vk::ImageAspectFlagBits::eDepth)) {
             throw std::invalid_argument("Selected texture does not contain depth aspect.");
         }
 
@@ -340,9 +337,7 @@ namespace Engine::RenderSystemState {
         if (pimpl->m_pending_operations.empty()) {
             // We do not need to worry about synchronization too much
             // as timeline semaphores are guaranteed to be monotonically increasing.
-            m_system.GetDevice().signalSemaphore(
-                frame_semaphore.GetSignalInfo(2)
-            );
+            m_system.GetDevice().signalSemaphore(frame_semaphore.GetSignalInfo(2));
             return;
         }
 
@@ -369,9 +364,7 @@ namespace Engine::RenderSystemState {
         pimpl->m_one_time_cb->end();
 
         vk::SemaphoreSubmitInfo signal_info{};
-        signal_info = frame_semaphore.GetSubmitInfo(
-            2, vk::PipelineStageFlagBits2::eAllTransfer
-        );
+        signal_info = frame_semaphore.GetSubmitInfo(2, vk::PipelineStageFlagBits2::eAllTransfer);
         vk::CommandBufferSubmitInfo cbsinfo{pimpl->m_one_time_cb.get()};
         // We don't need to wait for anything thanks to fences in the frame manager.
         vk::SubmitInfo2 sinfo{vk::SubmitFlags{}, {}, {cbsinfo}, {signal_info}};

--- a/engine/Render/RenderSystem/SubmissionHelper.h
+++ b/engine/Render/RenderSystem/SubmissionHelper.h
@@ -3,7 +3,7 @@
 
 #include <functional>
 #include <queue>
-#include <vector>
+#include <span>
 
 namespace Engine {
     class RenderSystem;
@@ -30,23 +30,13 @@ namespace Engine {
              *
              * @param buffer buffer to be uploaded
              * @param data Host-side buffer containing all data.
+             * These data are immediately copied to a staging buffer, and can
+             * be freed after the invocation.
              */
             void EnqueueBufferSubmission(
                 const DeviceBuffer &buffer,
-                std::vector<std::byte> &&data
-            );
-
-            /**
-             * @brief Enqueue a buffer uploading.
-             *
-             * @param buffer buffer to be uploaded
-             * @param data Host-side buffer containing all data.
-             * Data are immediately copied to a staging buffer.
-             * It is safe to free this buffer after calling this method.
-             */
-            void EnqueueBufferSubmission(
-                const DeviceBuffer &buffer,
-                const std::vector<std::byte> &data
+                std::span<const std::byte> data,
+                size_t buffer_offset = 0
             );
 
             /**
@@ -69,7 +59,10 @@ namespace Engine {
              * It is safe to free this buffer after calling this method.
              * @param length
              */
-            void EnqueueTextureBufferSubmission(const Texture &texture, const std::byte *data, size_t length);
+            void EnqueueTextureBufferSubmission(
+                const Texture &texture,
+                std::span<const std::byte> data
+            );
 
             /**
              * @brief Enqueue a texture clear operation.

--- a/engine/Render/RenderSystem/SubmissionHelper.h
+++ b/engine/Render/RenderSystem/SubmissionHelper.h
@@ -31,7 +31,10 @@ namespace Engine {
              * @param buffer buffer to be uploaded
              * @param data Host-side buffer containing all data.
              */
-            void EnqueueBufferSubmission(const DeviceBuffer &buffer, std::vector<std::byte> &&data);
+            void EnqueueBufferSubmission(
+                const DeviceBuffer &buffer,
+                std::vector<std::byte> &&data
+            );
 
             /**
              * @brief Enqueue a buffer uploading.
@@ -41,16 +44,10 @@ namespace Engine {
              * Data are immediately copied to a staging buffer.
              * It is safe to free this buffer after calling this method.
              */
-            void EnqueueBufferSubmission(const DeviceBuffer &buffer, const std::vector<std::byte> &data);
-
-            /**
-             * @brief Enqueue a buffer uploading.
-             *
-             * This method functions the same as `EnqueueBufferSubmission`,
-             * except that the uploaded buffer is considered a vertex & index
-             * buffer, and is synchronized as such.
-             */
-            void EnqueueBufferSubmissionVertex(const DeviceBuffer &vertex_buffer, const std::vector<std::byte> &data);
+            void EnqueueBufferSubmission(
+                const DeviceBuffer &buffer,
+                const std::vector<std::byte> &data
+            );
 
             /**
              * @brief Enqueue a texture buffer submission. Record corresponding image

--- a/engine/Render/RenderSystem/SubmissionHelper.h
+++ b/engine/Render/RenderSystem/SubmissionHelper.h
@@ -34,9 +34,7 @@ namespace Engine {
              * be freed after the invocation.
              */
             void EnqueueBufferSubmission(
-                const DeviceBuffer &buffer,
-                std::span<const std::byte> data,
-                size_t buffer_offset = 0
+                const DeviceBuffer &buffer, std::span<const std::byte> data, size_t buffer_offset = 0
             );
 
             /**
@@ -59,10 +57,7 @@ namespace Engine {
              * It is safe to free this buffer after calling this method.
              * @param length
              */
-            void EnqueueTextureBufferSubmission(
-                const Texture &texture,
-                std::span<const std::byte> data
-            );
+            void EnqueueTextureBufferSubmission(const Texture &texture, std::span<const std::byte> data);
 
             /**
              * @brief Enqueue a texture clear operation.

--- a/engine/Render/Resource/StaticMeshResource.cpp
+++ b/engine/Render/Resource/StaticMeshResource.cpp
@@ -77,7 +77,7 @@ namespace Engine {
                 buf.data() + submesh_ref.vertex_attribute_count * submesh_ref.attributes.GetTotalPerVertexSize()
             );
 
-            helper.EnqueueBufferSubmissionVertex(*submesh_ref.vi_buffer, buf);
+            helper.EnqueueBufferSubmission(*submesh_ref.vi_buffer, buf);
         }
 
         m_mesh_asset_ref.Release();

--- a/test/mrt_test.cpp
+++ b/test/mrt_test.cpp
@@ -275,9 +275,6 @@ int main(int argc, char **argv) {
 
         auto index = rsys->StartFrame();
 
-        // Test readback on the next color attachment for fixed layout
-        auto buf = rsys->GetFrameManager().EnqueuePostGraphicsImageReadback(*colors[(color + 1) % 4], 0, 0);
-
         rg.AddExternalOutputDependency(g_color_handles[(color + 1) % 4], MemoryAccessTypeImageBits::TransferRead);
         rg.Execute(*rsys);
 

--- a/test/mrt_test.cpp
+++ b/test/mrt_test.cpp
@@ -184,14 +184,16 @@ auto BuildRenderGraph(
     );
 
     rgb.AddPass(
-        RenderGraphPassBuilder{*rsys}.SetName("Transfer")
-        .UseBuffer(b1, {MemoryAccessTypeBufferBits::TransferWrite})
-        .UseImage(c1, MemoryAccessTypeImageBits::TransferRead)
-        .SetTransferPassFunction([readback, c1](TransferCommandBuffer &tcb, const RenderGraph2 & rg) {
-            auto rt = rg.GetInternalTextureResource(c1);
-            std::array image_copies = {
-                vk::BufferImageCopy{
-                    0, 0, 0,
+        RenderGraphPassBuilder{*rsys}
+            .SetName("Transfer")
+            .UseBuffer(b1, {MemoryAccessTypeBufferBits::TransferWrite})
+            .UseImage(c1, MemoryAccessTypeImageBits::TransferRead)
+            .SetTransferPassFunction([readback, c1](TransferCommandBuffer &tcb, const RenderGraph2 &rg) {
+                auto rt = rg.GetInternalTextureResource(c1);
+                std::array image_copies = {vk::BufferImageCopy{
+                    0,
+                    0,
+                    0,
                     vk::ImageSubresourceLayers{vk::ImageAspectFlagBits::eColor, 0, 0, 1},
                     vk::Offset3D{0, 0, 0},
                     vk::Extent3D{
@@ -199,16 +201,12 @@ auto BuildRenderGraph(
                         rt->GetTextureDescription().height,
                         rt->GetTextureDescription().depth
                     }
-                }
-            };
-            tcb.GetCommandBuffer().copyImageToBuffer(
-                rt->GetImage(),
-                vk::ImageLayout::eTransferSrcOptimal,
-                readback->GetBuffer(),
-                image_copies
-            );
-        })
-        .Get()
+                }};
+                tcb.GetCommandBuffer().copyImageToBuffer(
+                    rt->GetImage(), vk::ImageLayout::eTransferSrcOptimal, readback->GetBuffer(), image_copies
+                );
+            })
+            .Get()
     );
 
     return rgb.BuildRenderGraph();
@@ -312,19 +310,16 @@ int main(int argc, char **argv) {
 
         auto index = rsys->StartFrame();
 
-        rsys->GetFrameManager().RegisterReadbackCallback(
-            *readback_buffer,
-            [] (std::unique_ptr <DeviceBuffer> in) {
-                auto byte = in->GetVMAddress();
-                
-                for (int i = 0; i < 16; i++) {
-                    for (int j = 0; j < 16; j++) {
-                        std::cout << (int)byte[i * 16 + j] << " ";
-                    }
-                    std::cout << "\n";
+        rsys->GetFrameManager().RegisterReadbackCallback(*readback_buffer, [](std::unique_ptr<DeviceBuffer> in) {
+            auto byte = in->GetVMAddress();
+
+            for (int i = 0; i < 16; i++) {
+                for (int j = 0; j < 16; j++) {
+                    std::cout << (int)byte[i * 16 + j] << " ";
                 }
+                std::cout << "\n";
             }
-        );
+        });
 
         rg.Execute(*rsys);
 

--- a/test/mrt_test.cpp
+++ b/test/mrt_test.cpp
@@ -16,6 +16,7 @@
 #include <Asset/AssetDatabase/FileSystemDatabase.h>
 
 #include "cmake_config.h"
+#include <iostream>
 
 using namespace Engine;
 namespace sch = std::chrono;
@@ -90,6 +91,7 @@ std::array<RGTextureHandle, 4> g_color_handles = {};
 
 auto BuildRenderGraph(
     RenderSystem *rsys,
+    DeviceBuffer *readback,
     RenderTargetTexture *color_1,
     RenderTargetTexture *color_2,
     RenderTargetTexture *color_3,
@@ -104,6 +106,7 @@ auto BuildRenderGraph(
     auto c2 = rgb.ImportExternalResource(*color_2);
     auto c3 = rgb.ImportExternalResource(*color_3);
     auto c4 = rgb.ImportExternalResource(*color_4);
+    auto b1 = rgb.ImportExternalResource(*readback);
     auto d0 = rgb.ImportExternalResource(*depth);
 
     g_color_handles = {c1, c2, c3, c4};
@@ -180,6 +183,34 @@ auto BuildRenderGraph(
             .Get()
     );
 
+    rgb.AddPass(
+        RenderGraphPassBuilder{*rsys}.SetName("Transfer")
+        .UseBuffer(b1, {MemoryAccessTypeBufferBits::TransferWrite})
+        .UseImage(c1, MemoryAccessTypeImageBits::TransferRead)
+        .SetTransferPassFunction([readback, c1](TransferCommandBuffer &tcb, const RenderGraph2 & rg) {
+            auto rt = rg.GetInternalTextureResource(c1);
+            std::array image_copies = {
+                vk::BufferImageCopy{
+                    0, 0, 0,
+                    vk::ImageSubresourceLayers{vk::ImageAspectFlagBits::eColor, 0, 0, 1},
+                    vk::Offset3D{0, 0, 0},
+                    vk::Extent3D{
+                        rt->GetTextureDescription().width,
+                        rt->GetTextureDescription().height,
+                        rt->GetTextureDescription().depth
+                    }
+                }
+            };
+            tcb.GetCommandBuffer().copyImageToBuffer(
+                rt->GetImage(),
+                vk::ImageLayout::eTransferSrcOptimal,
+                readback->GetBuffer(),
+                image_copies
+            );
+        })
+        .Get()
+    );
+
     return rgb.BuildRenderGraph();
 }
 
@@ -243,11 +274,17 @@ int main(int argc, char **argv) {
         RenderTargetTexture::CreateUnique(*rsys, desc, Texture::SamplerDesc{}, "Color Attachment (Normal)"),
         RenderTargetTexture::CreateUnique(*rsys, desc, Texture::SamplerDesc{}, "Color Attachment (Texcoord)")
     };
+    auto readback_buffer = DeviceBuffer::CreateUnique(
+        rsys->GetAllocatorState(),
+        Engine::BufferType{Engine::BufferTypeBits::CopyTo, Engine::BufferTypeBits::CopyFrom},
+        colors[0]->CalculateStagingBufferSizeNoMipmap()
+    );
 
     auto asys = cmc->GetAssetManager();
 
     auto rg{BuildRenderGraph(
         rsys.get(),
+        readback_buffer.get(),
         colors[0].get(),
         colors[1].get(),
         colors[2].get(),
@@ -275,11 +312,27 @@ int main(int argc, char **argv) {
 
         auto index = rsys->StartFrame();
 
-        rg.AddExternalOutputDependency(g_color_handles[(color + 1) % 4], MemoryAccessTypeImageBits::TransferRead);
+        rsys->GetFrameManager().RegisterReadbackCallback(
+            *readback_buffer,
+            [] (std::unique_ptr <DeviceBuffer> in) {
+                auto byte = in->GetVMAddress();
+                
+                for (int i = 0; i < 16; i++) {
+                    for (int j = 0; j < 16; j++) {
+                        std::cout << (int)byte[i * 16 + j] << " ";
+                    }
+                    std::cout << "\n";
+                }
+            }
+        );
+
         rg.Execute(*rsys);
 
         rsys->CompleteFrame(
-            *colors[color], colors[color]->GetTextureDescription().width, colors[color]->GetTextureDescription().height
+            *colors[color],
+            color == 0 ? MemoryAccessTypeImageBits::TransferRead : MemoryAccessTypeImageBits::ColorAttachmentWrite,
+            colors[color]->GetTextureDescription().width,
+            colors[color]->GetTextureDescription().height
         );
 
         SDL_Delay(10);

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -286,7 +286,7 @@ int main(int argc, char **argv) {
         }
 
         rsys->GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-            *allocated_image_texture, 
+            *allocated_image_texture,
             std::span{test_texture_asset->GetPixelData(), test_texture_asset->GetPixelDataSize()}
         );
 

--- a/test/new_material_test.cpp
+++ b/test/new_material_test.cpp
@@ -286,7 +286,8 @@ int main(int argc, char **argv) {
         }
 
         rsys->GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-            *allocated_image_texture, test_texture_asset->GetPixelData(), test_texture_asset->GetPixelDataSize()
+            *allocated_image_texture, 
+            std::span{test_texture_asset->GetPixelData(), test_texture_asset->GetPixelDataSize()}
         );
 
         auto index = rsys->StartFrame();

--- a/test/skybox_test.cpp
+++ b/test/skybox_test.cpp
@@ -140,7 +140,8 @@ int main(int argc, char **argv) {
 
         // cubemap->LoadFromFile(CUBEMAP_FACES);
         rsys->GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-            *skybox_texture, cubemap->GetPixelData(), cubemap->GetPixelDataSize()
+            *skybox_texture,
+            std::span{cubemap->GetPixelData(), cubemap->GetPixelDataSize()}
         );
         rsys->GetFrameManager().GetSubmissionHelper().ExecuteSubmissionImmediately();
     }

--- a/test/skybox_test.cpp
+++ b/test/skybox_test.cpp
@@ -140,8 +140,7 @@ int main(int argc, char **argv) {
 
         // cubemap->LoadFromFile(CUBEMAP_FACES);
         rsys->GetFrameManager().GetSubmissionHelper().EnqueueTextureBufferSubmission(
-            *skybox_texture,
-            std::span{cubemap->GetPixelData(), cubemap->GetPixelDataSize()}
+            *skybox_texture, std::span{cubemap->GetPixelData(), cubemap->GetPixelDataSize()}
         );
         rsys->GetFrameManager().GetSubmissionHelper().ExecuteSubmissionImmediately();
     }


### PR DESCRIPTION
This PR brings in some ad hoc improvements on the Synchronization API, specifically around these three classes: `FrameManager`, `SubmissionHelper` and `FrameSemaphore`. Hardcoded synch points in the FrameSemaphore are replaced. Multiple interfaces around the resource submission are simplified. Readback logic of the buffers are also revised.