### PR TITLE
Update cpp-linter.yml

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches: [main, master, develop]
     paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     permissions: 
       pull-requests: write
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
       - uses: cpp-linter/cpp-linter-action@main


### PR DESCRIPTION
Disables cpp-linter for draft PRs.

Taken from https://github.com/orgs/community/discussions/25722#discussioncomment-3248917